### PR TITLE
fix: 환경변수 이슈로 git clean 삭제

### DIFF
--- a/.script/deploy.sh
+++ b/.script/deploy.sh
@@ -4,7 +4,6 @@ docker-compose down
 
 git reset
 git checkout .
-git clean -fdx
 
 git pull
 


### PR DESCRIPTION
실제 host 에 .env.prod 파일을 git untracked 상태로 보관하고 있는데,
git clean 명령어를 하면 untracked 파일을 삭제 해버려서 env 파일이 적용되지 않는 문제가 생김

그래서 배포 과정에 있는 git clean을 삭제 했습니다.