### PR TITLE
Style: 채팅 목록 순서 역순으로 변경, 숫자 줄옮김 안되는 이슈 해결

### DIFF
--- a/frontend/src/hooks/useSetSocketHandler.ts
+++ b/frontend/src/hooks/useSetSocketHandler.ts
@@ -18,7 +18,7 @@ export function useSetSocketHandler() {
   function disconnectHandler() {}
 
   function getCurrentChatHandler(data: ChatDataType) {
-    setCurrentChatData(prev => [...prev, data]);
+    setCurrentChatData(prev => [data, ...prev]);
   }
   function getAllChatRoomHandler(data: ChatRoomInfoType[]) {
     setChatRoomList(data);

--- a/frontend/src/pages/ChatPage/ChatElement.styles.ts
+++ b/frontend/src/pages/ChatPage/ChatElement.styles.ts
@@ -77,9 +77,9 @@ export const chatMessageWrapper = css`
   padding: 10px;
   height: fit-content;
   flex: 1;
+  overflow: hidden;
 
-
-  & > span: {
-    // TODO: style
+  & > p {
+   word-break: break-all;
   },
 `;

--- a/frontend/src/pages/ChatPage/ChatElement.styles.ts
+++ b/frontend/src/pages/ChatPage/ChatElement.styles.ts
@@ -3,12 +3,13 @@ import { css } from '@emotion/css';
 export const chatElementWrapper = (isMine: boolean) =>
   css`
     padding: 10px;
-    overflow: hidden;
     width: calc(100% - 20px);
+    flex: 1;
     display: flex;
     flex-direction: row;
     justify-content: ${isMine ? 'flex-end' : 'flex-start'};
     align-items: flex-start;
+    margin-top: 5px;
   `;
 
 export const chatProfileWrapper = css`
@@ -18,6 +19,8 @@ export const chatProfileWrapper = css`
   flex-direction: column;
   align-items: center;
   margin-right: 20px;
+  color: black; // TODO: 상수화
+  text-decoration: none;
 
   & > img {
     width: 50px;
@@ -42,7 +45,7 @@ export const chatProfileWrapper = css`
   & > span {
     margin-top: 3px;
     width: 70px;
-    line-height: 15px;
+    line-height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -52,7 +55,7 @@ export const chatProfileWrapper = css`
 
 export const chatBodyWrapper = css`
   max-width: calc(100% - 90px);
-  height: 100%;
+  height: 80%;
   display: flex;
   flex-direction: row;
   align-items: flex-end;
@@ -74,7 +77,7 @@ export const chatMessageWrapper = css`
   padding: 10px;
   height: fit-content;
   flex: 1;
-  margin-top: 10px;
+
 
   & > span: {
     // TODO: style

--- a/frontend/src/pages/ChatPage/ChatElement.tsx
+++ b/frontend/src/pages/ChatPage/ChatElement.tsx
@@ -28,7 +28,7 @@ export const ChatElement = ({ chatUser, message, timestamp, isMine }: Props) => 
         <div className={chatBodyWrapper}>
           <span className={chatTimestampWrapper(true)}>{new Date(timestamp).toLocaleTimeString()}</span>
           <div className={chatMessageWrapper}>
-            <span>{message}</span>
+            <p>{message}</p>
           </div>
         </div>
       </li>
@@ -43,7 +43,7 @@ export const ChatElement = ({ chatUser, message, timestamp, isMine }: Props) => 
       </Link>
       <div className={chatBodyWrapper}>
         <div className={chatMessageWrapper}>
-          <span>{message}</span>
+          <p>{message}</p>
         </div>
         <span className={chatTimestampWrapper(false)}>{new Date(timestamp).toLocaleTimeString()}</span>
       </div>

--- a/frontend/src/pages/ChatPage/ChatElement.tsx
+++ b/frontend/src/pages/ChatPage/ChatElement.tsx
@@ -1,4 +1,7 @@
+import { Link } from 'react-router-dom';
+
 import { CrownIcon } from 'assets';
+import { ROUTE } from 'common/constants';
 import { ChatUserInfoType } from 'types/chat';
 
 import {
@@ -17,7 +20,7 @@ interface Props {
 }
 
 export const ChatElement = ({ chatUser, message, timestamp, isMine }: Props) => {
-  const { nickname, avatar } = chatUser.user;
+  const { nickname, avatar, id } = chatUser.user;
 
   if (isMine)
     return (
@@ -33,11 +36,11 @@ export const ChatElement = ({ chatUser, message, timestamp, isMine }: Props) => 
 
   return (
     <li className={chatElementWrapper(false)}>
-      <div className={chatProfileWrapper}>
+      <Link to={`${ROUTE.PROFILE}/${id}`} className={chatProfileWrapper}>
         <img src={avatar} alt={`${nickname}-profile`} width={50} height={50} />
         <span>{nickname}</span>
         {chatUser.isOperator && <CrownIcon />}
-      </div>
+      </Link>
       <div className={chatBodyWrapper}>
         <div className={chatMessageWrapper}>
           <span>{message}</span>

--- a/frontend/src/pages/ChatPage/ChatPage.styles.ts
+++ b/frontend/src/pages/ChatPage/ChatPage.styles.ts
@@ -34,6 +34,8 @@ export const chatPageMenuButtonStyle = css`
 
 export const chatPageListWrapperStyle = css`
   flex: 1;
+  display: flex;
+  flex-direction: column-reverse;
   overflow-x: hidden;
   overflow-y: scroll;
 `;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37893979/218385526-a04c6993-79fe-4e61-9d01-a92879dc52c8.png)

1. `display: flex; flex-direction: column-reverse;` 로 플렉스박스 자체를 뒤집은 뒤, 채팅 순서를 역순으로 저장하면 됩니다. 소소하게 디자인이 깨지는 이슈가 있었는데 flex: 1 로 해결했습니다
2. `word-break: break-all` 을 적용하면 모든 문자에 대해서 줄옮김을 적용해줍니다.