### PR TITLE
Feat/register

### DIFF
--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -4,7 +4,8 @@ import { Response } from 'express';
 import { ReqFtProfile } from '../../common/auth/ft-auth';
 import { FtAuthGuard } from '../../common/auth/ft-auth/ft-auth.guard';
 import { FtJwtAuthGuard, ReqJwtFtProfile } from '../../common/auth/jwt-auth';
-import { FtProfile } from '../../common/auth/types';
+import { FtProfile, UserJwtPayload } from '../../common/auth/types';
+import { User } from '../../common/database/entities/user.entity';
 import { RegisterRequestDto } from './dto/request/register.dto';
 import { FtProfileDto } from './dto/response/ft-profile.dto';
 import { CookieService } from './service/cookie.service';
@@ -37,7 +38,7 @@ export class AuthController {
     @ReqFtProfile() ftProfile: FtProfile,
     @Res({ passthrough: true }) response: Response,
   ): Promise<FtProfileDto> {
-    const jwt = this.cookieService.createJwt(ftProfile);
+    const jwt = this.cookieService.createJwt<FtProfile>(ftProfile);
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('ft_profile', jwt, cookieOption);
@@ -59,7 +60,7 @@ export class AuthController {
       username: `Pochita${randomId}`,
       image_url: 'https://beebom.com/wp-content/uploads/2022/10/Cute-Weakened-form-of-Pochita.jpg?w=640',
     };
-    const jwt = this.cookieService.createJwt(ftProfile);
+    const jwt = this.cookieService.createJwt<FtProfile>(ftProfile);
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('ft_profile', jwt, cookieOption);
@@ -69,33 +70,43 @@ export class AuthController {
   @UseGuards(FtJwtAuthGuard)
   @ApiCookieAuth()
   @ApiOperation({ summary: '로그인 하기 (42인증 후에 진행해주세요)' })
-  @ApiOkResponse({ description: '로그인 성공' })
+  @ApiOkResponse({ description: '로그인 성공', type: User })
   async login(
     @ReqJwtFtProfile() ftProfile: FtProfile, //
     @Res({ passthrough: true }) response: Response,
-  ): Promise<void> {
-    const jwtPayload = await this.loginService.login(ftProfile);
-    const jwt = this.cookieService.createJwt(jwtPayload);
+  ): Promise<User> {
+    const user = await this.loginService.login(ftProfile);
+    const jwt = this.cookieService.createJwt<UserJwtPayload>({
+      id: user.id,
+      intraId: user.intraId,
+    });
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('access_token', jwt, cookieOption);
+
+    return user;
   }
 
   @Post('register')
   @UseGuards(FtJwtAuthGuard)
   @ApiCookieAuth()
   @ApiOperation({ summary: '회원가입 하기 (42인증 후에 진행해주세요)' })
-  @ApiOkResponse({ description: '회원가입 성공' })
+  @ApiOkResponse({ description: '회원가입 성공', type: User })
   async register(
     @ReqJwtFtProfile() ftProfile: FtProfile, //
     @Body() registerDto: RegisterRequestDto,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<void> {
-    const jwtPayload = await this.loginService.register(ftProfile, registerDto);
-    const jwt = this.cookieService.createJwt(jwtPayload);
+  ): Promise<User> {
+    const user = await this.loginService.register(ftProfile, registerDto);
+    const jwt = this.cookieService.createJwt<UserJwtPayload>({
+      id: user.id,
+      intraId: user.intraId,
+    });
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('access_token', jwt, cookieOption);
+
+    return user;
   }
 
   @Delete('signout')

--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -1,19 +1,29 @@
-import { Controller, Delete, Get, Query, Res, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiOkResponse, ApiOperation, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Post, Res, UseGuards } from '@nestjs/common';
+import { ApiCookieAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
-import { FtProfile, ReqFtProfile } from '../../common/auth/ft-auth';
+import { ReqFtProfile } from '../../common/auth/ft-auth';
 import { FtAuthGuard } from '../../common/auth/ft-auth/ft-auth.guard';
-import { JwtAuthGuard } from '../../common/auth/jwt-auth';
+import { FtJwtAuthGuard, ReqJwtFtProfile } from '../../common/auth/jwt-auth';
+import { FtProfile } from '../../common/auth/types';
+import { RegisterRequestDto } from './dto/request/register.dto';
+import { FtProfileDto } from './dto/response/ft-profile.dto';
+import { CookieService } from './service/cookie.service';
 import { LoginService } from './service/login.service';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly loginService: LoginService) {}
+  constructor(
+    private readonly cookieService: CookieService, //
+    private readonly loginService: LoginService,
+  ) {}
 
   @Get('ft')
   @UseGuards(FtAuthGuard)
-  @ApiOperation({ summary: '42 로그인', description: '42 로그인 페이지로 리다이렉트' })
+  @ApiOperation({
+    summary: '42 로그인',
+    description: "42 로그인 페이지로 리다이렉트 <a href='/auth/ft'> Please cmd + click me! </a>",
+  })
   @ApiOkResponse({ description: '42 페이지' })
   ftLogin(): void {
     return;
@@ -27,38 +37,85 @@ export class AuthController {
     @ReqFtProfile() ftProfile: FtProfile,
     @Res({ passthrough: true }) response: Response,
   ): Promise<void> {
-    const jwt = await this.loginService.login(ftProfile);
-    const cookieOption = this.loginService.getCookieOption();
+    console.log('ftProfile', ftProfile);
+
+    const jwt = this.cookieService.createJwt(ftProfile);
+    const cookieOption = this.cookieService.getCookieOption();
+
+    response.cookie('ft_profile', jwt, cookieOption);
+  }
+
+  @Get('ft/random')
+  @ApiOperation({ summary: '42 랜덤하게 로그인하기 (개발용입니다.)' })
+  @ApiOkResponse({ description: '로그인 성공' })
+  async getJwt(@Res({ passthrough: true }) response: Response): Promise<void> {
+    const randomId = String(Math.floor(Math.random() * 10000));
+    const ftProfile = {
+      id: `Z${randomId}`,
+      username: `Pochita${randomId}`,
+      image_url: 'https://beebom.com/wp-content/uploads/2022/10/Cute-Weakened-form-of-Pochita.jpg?w=640',
+    };
+    const jwt = this.cookieService.createJwt(ftProfile);
+    const cookieOption = this.cookieService.getCookieOption();
+
+    response.cookie('ft_profile', jwt, cookieOption);
+  }
+
+  @Get('ft/profile')
+  @UseGuards(FtJwtAuthGuard)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '42 프로필 확인 (42인증 후에 진행해주세요)' })
+  @ApiOkResponse({ description: '42 프로필', type: FtProfileDto })
+  profile(
+    @ReqJwtFtProfile() ftProfile: FtProfile, //
+  ): FtProfileDto {
+    return {
+      id: ftProfile.id,
+      username: ftProfile.username,
+      image_url: ftProfile.image_url,
+    };
+  }
+
+  @Get('login')
+  @UseGuards(FtJwtAuthGuard)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '로그인 하기 (42인증 후에 진행해주세요)' })
+  @ApiOkResponse({ description: '로그인 성공' })
+  async login(
+    @ReqJwtFtProfile() ftProfile: FtProfile, //
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<void> {
+    const jwtPayload = await this.loginService.login(ftProfile);
+    const jwt = this.cookieService.createJwt(jwtPayload);
+    const cookieOption = this.cookieService.getCookieOption();
+
+    response.cookie('access_token', jwt, cookieOption);
+  }
+
+  @Post('register')
+  @UseGuards(FtJwtAuthGuard)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '회원가입 하기 (42인증 후에 진행해주세요)' })
+  @ApiOkResponse({ description: '회원가입 성공' })
+  async register(
+    @ReqJwtFtProfile() ftProfile: FtProfile, //
+    @Body() registerDto: RegisterRequestDto,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<void> {
+    const jwtPayload = await this.loginService.register(ftProfile, registerDto);
+    const jwt = this.cookieService.createJwt(jwtPayload);
+    const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('access_token', jwt, cookieOption);
   }
 
   @Delete('signout')
-  @ApiCookieAuth()
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: '로그아웃' })
   @ApiOkResponse({ description: '로그아웃 성공' })
-  @ApiUnauthorizedResponse({ description: '로그인이 필요합니다.' })
   signout(@Res({ passthrough: true }) response: Response): void {
-    const cookieOption = this.loginService.getCookieOption();
+    const cookieOption = this.cookieService.getCookieOption();
 
     response.clearCookie('access_token', cookieOption);
-  }
-
-  @Get('debug/login/random')
-  @ApiOperation({ summary: '랜덤하게 로그인하기 (개발용입니다.)' })
-  @ApiOkResponse({ description: '로그인 성공' })
-  async getJwt(
-    @Res({ passthrough: true }) response: Response, //
-    @Query('name') name: string,
-  ): Promise<void> {
-    const jwt = await this.loginService.login({
-      id: `Z${String(Math.floor(Math.random() * 10000))}`,
-      username: `P${name}`,
-      image_url: 'https://beebom.com/wp-content/uploads/2022/10/Cute-Weakened-form-of-Pochita.jpg?w=640',
-    });
-    const cookieOption = this.loginService.getCookieOption();
-
-    response.cookie('access_token', jwt, cookieOption);
+    response.clearCookie('ft_profile', cookieOption);
   }
 }

--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -52,8 +52,8 @@ export class AuthController {
 
   @Get('ft/random')
   @ApiOperation({ summary: '42 랜덤하게 로그인하기 (개발용입니다.)' })
-  @ApiOkResponse({ description: '로그인 성공' })
-  async getJwt(@Res({ passthrough: true }) response: Response): Promise<void> {
+  @ApiOkResponse({ description: '로그인 성공', type: FtProfileDto })
+  async getJwt(@Res({ passthrough: true }) response: Response): Promise<FtProfileDto> {
     const randomId = String(Math.floor(Math.random() * 10000));
     const ftProfile = {
       id: `Z${randomId}`,
@@ -64,6 +64,8 @@ export class AuthController {
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('ft_profile', jwt, cookieOption);
+
+    return ftProfile;
   }
 
   @Get('login')

--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -32,17 +32,21 @@ export class AuthController {
   @Get('ft/callback')
   @UseGuards(FtAuthGuard)
   @ApiOperation({ summary: '42 로그인 콜백' })
-  @ApiOkResponse({ description: '로그인 성공' })
+  @ApiOkResponse({ description: '로그인 성공', type: FtProfileDto })
   async ftCallback(
     @ReqFtProfile() ftProfile: FtProfile,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<void> {
-    console.log('ftProfile', ftProfile);
-
+  ): Promise<FtProfileDto> {
     const jwt = this.cookieService.createJwt(ftProfile);
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('ft_profile', jwt, cookieOption);
+
+    return {
+      id: ftProfile.id,
+      username: ftProfile.username,
+      image_url: ftProfile.image_url,
+    };
   }
 
   @Get('ft/random')
@@ -59,21 +63,6 @@ export class AuthController {
     const cookieOption = this.cookieService.getCookieOption();
 
     response.cookie('ft_profile', jwt, cookieOption);
-  }
-
-  @Get('ft/profile')
-  @UseGuards(FtJwtAuthGuard)
-  @ApiCookieAuth()
-  @ApiOperation({ summary: '42 프로필 확인 (42인증 후에 진행해주세요)' })
-  @ApiOkResponse({ description: '42 프로필', type: FtProfileDto })
-  profile(
-    @ReqJwtFtProfile() ftProfile: FtProfile, //
-  ): FtProfileDto {
-    return {
-      id: ftProfile.id,
-      username: ftProfile.username,
-      image_url: ftProfile.image_url,
-    };
   }
 
   @Get('login')

--- a/backend/src/api/auth/auth.module.ts
+++ b/backend/src/api/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { User } from '../../common/database/entities/user.entity';
 import { AuthController } from './auth.controller';
 import { FtAuthModule } from './ft-auth/ft-auth.module';
 import { JwtAuthModule } from './jwt-auth/jwt-auth.module';
+import { CookieService } from './service/cookie.service';
 import { LoginService } from './service/login.service';
 
 @Module({
@@ -22,7 +23,7 @@ import { LoginService } from './service/login.service';
     }),
     TypeOrmModule.forFeature([User]),
   ],
-  providers: [LoginService],
+  providers: [CookieService, LoginService],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/backend/src/api/auth/dto/request/register.dto.ts
+++ b/backend/src/api/auth/dto/request/register.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class RegisterRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'jasong' })
+  nickname: string;
+
+  @IsOptional()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'https://picsum.photos/200' })
+  avatar: string;
+}

--- a/backend/src/api/auth/dto/response/ft-profile.dto.ts
+++ b/backend/src/api/auth/dto/response/ft-profile.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FtProfileDto {
+  @ApiProperty({ example: '80406', description: '인트라 고유 유저 아이디' })
+  id: string;
+
+  @ApiProperty({ example: 'ycha', description: '인트라 아이디' })
+  username: string;
+
+  @ApiProperty({
+    example: 'https://cdn.intra.42.fr/users/default.jpg',
+    description: '인트라 프로필 이미지',
+  })
+  image_url: string;
+}

--- a/backend/src/api/auth/ft-auth/ft-auth.strategy.ts
+++ b/backend/src/api/auth/ft-auth/ft-auth.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
+import { FtProfile } from '../../../common/auth/types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const FortyTwoPassport = require('passport-42');
@@ -24,8 +25,12 @@ export class FtAuthStrategy extends PassportStrategy(FortyTwoPassport.Strategy) 
     accessToken: string,
     refreshToken: string,
     profile: Record<string, string>,
-    done: (err: unknown, data: Record<string, string>) => void,
+    done: (err: unknown, data: FtProfile) => void,
   ): Promise<void> {
-    done(null, profile);
+    done(null, {
+      id: profile.id,
+      username: profile.username,
+      image_url: profile.image_url,
+    });
   }
 }

--- a/backend/src/api/auth/jwt-auth/ft-jwt-auth.strategy.ts
+++ b/backend/src/api/auth/jwt-auth/ft-jwt-auth.strategy.ts
@@ -1,0 +1,25 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { Request } from 'express';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { FtProfile } from '../../../common/auth/types';
+
+@Injectable()
+export class FtJwtAuthStrategy extends PassportStrategy(Strategy, 'ft-jwt-auth') {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([(request: Request) => request.cookies['ft_profile']]),
+      ignoreExpiration: false,
+      secretOrKey: configService.get('JWT_SECRET'),
+    });
+  }
+
+  async validate(payload: FtProfile, done: (err: unknown, data: FtProfile) => void): Promise<void> {
+    if (!payload.id || !payload.username || !payload.image_url) {
+      throw new UnauthorizedException('Invalid ftProfile token');
+    }
+
+    done(null, payload);
+  }
+}

--- a/backend/src/api/auth/jwt-auth/jwt-auth.module.ts
+++ b/backend/src/api/auth/jwt-auth/jwt-auth.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../../../common/database/entities/user.entity';
-import { JwtAuthStrategy } from './jwt-auth.strategy';
+import { FtJwtAuthStrategy } from './ft-jwt-auth.strategy';
+import { UserJwtAuthStrategy } from './user-jwt-auth.strategy';
 
 @Module({
   imports: [PassportModule, TypeOrmModule.forFeature([User])],
-  providers: [JwtAuthStrategy],
+  providers: [FtJwtAuthStrategy, UserJwtAuthStrategy],
 })
 export class JwtAuthModule {}

--- a/backend/src/api/auth/jwt-auth/user-jwt-auth.strategy.ts
+++ b/backend/src/api/auth/jwt-auth/user-jwt-auth.strategy.ts
@@ -5,11 +5,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Repository } from 'typeorm';
-import { JwtPayload } from '../../../common/auth/jwt-auth';
+import { UserJwtPayload } from '../../../common/auth/types';
 import { User } from '../../../common/database/entities/user.entity';
 
 @Injectable()
-export class JwtAuthStrategy extends PassportStrategy(Strategy) {
+export class UserJwtAuthStrategy extends PassportStrategy(Strategy, 'user-jwt-auth') {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>, //
@@ -22,9 +22,9 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: JwtPayload, done: (err: unknown, data: User) => void): Promise<void> {
+  async validate(payload: UserJwtPayload, done: (err: unknown, data: User) => void): Promise<void> {
     if (!payload.id || !payload.intraId) {
-      throw new UnauthorizedException('Invalid token');
+      throw new UnauthorizedException('Invalid JwtPyaload token');
     }
 
     const user = await this.userRepository.findOne({ where: { id: payload.id, intraId: payload.intraId } });

--- a/backend/src/api/auth/service/cookie.service.ts
+++ b/backend/src/api/auth/service/cookie.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { CookieOptions } from 'express';
+
+@Injectable()
+export class CookieService {
+  constructor(
+    private readonly jwtService: JwtService, //
+    private readonly configService: ConfigService,
+  ) {}
+
+  getCookieOption(): CookieOptions {
+    const oneHour = 60 * 60 * 1000;
+    const maxAge = 7 * 24 * oneHour; // 7days
+
+    return this.configService.get('PROFILE') === 'production' //
+      ? { secure: true, sameSite: 'none', maxAge }
+      : { maxAge };
+  }
+
+  createJwt<T extends Record<string, string | number>>(payload: T): string {
+    return this.jwtService.sign(payload);
+  }
+}

--- a/backend/src/api/auth/service/login.service.ts
+++ b/backend/src/api/auth/service/login.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { FtProfile, UserJwtPayload } from '../../../common/auth/types';
+import { FtProfile } from '../../../common/auth/types';
 
 import { User } from '../../../common/database/entities/user.entity';
 import { RegisterRequestDto } from '../dto/request/register.dto';
@@ -13,7 +13,7 @@ export class LoginService {
     private readonly userRepository: Repository<User>, //
   ) {}
 
-  async login(ftProfile: FtProfile): Promise<UserJwtPayload> {
+  async login(ftProfile: FtProfile): Promise<User> {
     const user = await this.userRepository.findOne({
       where: { intraId: ftProfile.id },
     });
@@ -22,13 +22,10 @@ export class LoginService {
       throw new ForbiddenException('등록되지 않은 유저입니다.');
     }
 
-    return {
-      id: user.id,
-      intraId: user.intraId,
-    };
+    return user;
   }
 
-  async register(ftProfile: FtProfile, registerDto: RegisterRequestDto): Promise<UserJwtPayload> {
+  async register(ftProfile: FtProfile, registerDto: RegisterRequestDto): Promise<User> {
     const alreadyRegisteredUser = await this.userRepository.findOne({
       where: { intraId: ftProfile.id },
     });
@@ -51,9 +48,6 @@ export class LoginService {
       avatar: registerDto.avatar,
     });
 
-    return {
-      id: user.id,
-      intraId: user.intraId,
-    };
+    return user;
   }
 }

--- a/backend/src/api/user/dto/request/update-user-profile.dto.ts
+++ b/backend/src/api/user/dto/request/update-user-profile.dto.ts
@@ -1,14 +1,14 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class UpdateUserProfileRequestDto {
+  @IsString()
   @IsOptional()
-  @IsNotEmpty()
   @ApiPropertyOptional({ example: 'jasong' })
   nickname?: string;
 
+  @IsString()
   @IsOptional()
-  @IsNotEmpty()
   @ApiPropertyOptional({ example: 'https://picsum.photos/200' })
   avatar?: string;
 }

--- a/backend/src/api/user/service/update-profile.service.ts
+++ b/backend/src/api/user/service/update-profile.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../../../common/database/entities/user.entity';
-import { UpdateUserProfileRequestDto } from '../dto/update-user-profile-request.dto';
+import { UpdateUserProfileRequestDto } from '../dto/request/update-user-profile.dto';
 
 @Injectable()
 export class UpdateProfileService {
@@ -12,9 +12,30 @@ export class UpdateProfileService {
   ) {}
 
   async updateProfile(user: User, updateUserProfileDto: UpdateUserProfileRequestDto): Promise<void> {
+    const isNicknameAlreadyUsed = await this.isNicknameAlreadyUsed(user.nickname, updateUserProfileDto.nickname);
+    if (isNicknameAlreadyUsed) {
+      throw new BadRequestException(`${updateUserProfileDto.nickname} 는 이미 사용중인 닉네임입니다.`);
+    }
+
     await this.userRepository.save({
       ...user,
       ...updateUserProfileDto,
     });
+  }
+
+  private async isNicknameAlreadyUsed(oldNick: string, newNick: string | undefined): Promise<boolean> {
+    if (!newNick) {
+      return false;
+    }
+
+    if (oldNick === newNick) {
+      return false;
+    }
+
+    const alreadyUsedNickname = await this.userRepository.findOne({
+      where: { nickname: newNick },
+    });
+
+    return !!alreadyUsedNickname;
   }
 }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -7,7 +7,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { JwtAuthGuard, ReqUser } from '../../common/auth/jwt-auth';
+import { ReqUser, UserJwtAuthGuard } from '../../common/auth/jwt-auth';
 import { User } from '../../common/database/entities/user.entity';
 import { UpdateUserProfileRequestDto } from './dto/request/update-user-profile.dto';
 import { FindUserService } from './service/find-user.service';
@@ -16,7 +16,7 @@ import { UpdateProfileService } from './service/update-profile.service';
 @ApiTags('User')
 @Controller('users')
 @ApiCookieAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(UserJwtAuthGuard)
 @ApiUnauthorizedResponse({ description: '로그인이 필요합니다.' })
 export class UserController {
   constructor(

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -31,6 +31,9 @@ export class UserController {
     return await this.findUserService.findAll();
   }
 
+  /**
+   * @deprecated
+   */
   @Get('me')
   @ApiOperation({ summary: '내 정보 가져오기' })
   @ApiOkResponse({ description: '내 정보', type: User })

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard, ReqUser } from '../../common/auth/jwt-auth';
 import { User } from '../../common/database/entities/user.entity';
-import { UpdateUserProfileRequestDto } from './dto/update-user-profile-request.dto';
+import { UpdateUserProfileRequestDto } from './dto/request/update-user-profile.dto';
 import { FindUserService } from './service/find-user.service';
 import { UpdateProfileService } from './service/update-profile.service';
 

--- a/backend/src/common/auth/ft-auth/ft-auth.guard.ts
+++ b/backend/src/common/auth/ft-auth/ft-auth.guard.ts
@@ -15,7 +15,7 @@ export class FtAuthGuard extends AuthGuard('42') {
     try {
       return super.handleRequest(err, user, info, context, status);
     } catch (e: unknown) {
-      throw new BadRequestException((e as Error).message);
+      throw new BadRequestException(`42인증에 실패했습니다. 다시 시도해주세요. \n(${(e as Error).message})`);
     }
   }
 }

--- a/backend/src/common/auth/jwt-auth/ft-jwt-auth.guard.ts
+++ b/backend/src/common/auth/jwt-auth/ft-jwt-auth.guard.ts
@@ -1,0 +1,21 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+type EveryThing = string | number | boolean | null | undefined | Record<string, unknown>;
+
+@Injectable()
+export class FtJwtAuthGuard extends AuthGuard('ft-jwt-auth') {
+  handleRequest<TUser>(
+    err: EveryThing,
+    user: EveryThing,
+    info: EveryThing,
+    context: ExecutionContext,
+    status?: EveryThing,
+  ): TUser {
+    try {
+      return super.handleRequest(err, user, info, context, status);
+    } catch (e: unknown) {
+      throw new UnauthorizedException(`${(e as Error).message} : 42 인증을 했는지 확인해주세요`);
+    }
+  }
+}

--- a/backend/src/common/auth/jwt-auth/ft-jwt-auth.guard.ts
+++ b/backend/src/common/auth/jwt-auth/ft-jwt-auth.guard.ts
@@ -15,7 +15,9 @@ export class FtJwtAuthGuard extends AuthGuard('ft-jwt-auth') {
     try {
       return super.handleRequest(err, user, info, context, status);
     } catch (e: unknown) {
-      throw new UnauthorizedException(`${(e as Error).message} : 42 인증을 했는지 확인해주세요`);
+      throw new UnauthorizedException(
+        `42프로필 확인에 실패했습니다. 42 인증을 했는지 확인해주세요. \n(${(e as Error).message})`,
+      );
     }
   }
 }

--- a/backend/src/common/auth/jwt-auth/index.ts
+++ b/backend/src/common/auth/jwt-auth/index.ts
@@ -1,3 +1,4 @@
-export * from './jwt-auth.guard';
-export * from './jwtPayload';
+export * from './ft-jwt-auth.guard';
+export * from './req-jwt-ft-profile';
 export * from './req-user';
+export * from './user-jwt-auth.guard';

--- a/backend/src/common/auth/jwt-auth/req-jwt-ft-profile.ts
+++ b/backend/src/common/auth/jwt-auth/req-jwt-ft-profile.ts
@@ -4,7 +4,7 @@ import { FtProfile } from '../types';
 /**
  * @description Request에 담긴 FortyTwoProfile를 가져온다.
  */
-export const ReqFtProfile = createParamDecorator((data, ctx: ExecutionContext): FtProfile => {
+export const ReqJwtFtProfile = createParamDecorator((data, ctx: ExecutionContext): FtProfile => {
   const req = ctx.switchToHttp().getRequest();
   return req.user;
 });

--- a/backend/src/common/auth/jwt-auth/user-jwt-auth.guard.ts
+++ b/backend/src/common/auth/jwt-auth/user-jwt-auth.guard.ts
@@ -4,7 +4,7 @@ import { AuthGuard } from '@nestjs/passport';
 type EveryThing = string | number | boolean | null | undefined | Record<string, unknown>;
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {
+export class UserJwtAuthGuard extends AuthGuard('user-jwt-auth') {
   handleRequest<TUser>(
     err: EveryThing,
     user: EveryThing,
@@ -15,7 +15,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     try {
       return super.handleRequest(err, user, info, context, status);
     } catch (e: unknown) {
-      throw new UnauthorizedException((e as Error).message);
+      throw new UnauthorizedException(`${(e as Error).message} : 로그인을 했는지 확인해주세요`);
     }
   }
 }

--- a/backend/src/common/auth/jwt-auth/user-jwt-auth.guard.ts
+++ b/backend/src/common/auth/jwt-auth/user-jwt-auth.guard.ts
@@ -15,7 +15,9 @@ export class UserJwtAuthGuard extends AuthGuard('user-jwt-auth') {
     try {
       return super.handleRequest(err, user, info, context, status);
     } catch (e: unknown) {
-      throw new UnauthorizedException(`${(e as Error).message} : 로그인을 했는지 확인해주세요`);
+      throw new UnauthorizedException(
+        `유저 인증에 실패했습니다. 로그인을 했는지 확인해주세요. \n(${(e as Error).message})`,
+      );
     }
   }
 }

--- a/backend/src/common/auth/types/ftProfile.ts
+++ b/backend/src/common/auth/types/ftProfile.ts
@@ -1,0 +1,10 @@
+export type FtProfile = {
+  // 인트라 유저 고유 번호
+  id: string;
+
+  // 인트라 유저 이름
+  username: string;
+
+  // 이미지 주소
+  image_url: string;
+};

--- a/backend/src/common/auth/types/index.ts
+++ b/backend/src/common/auth/types/index.ts
@@ -1,0 +1,2 @@
+export * from './ftProfile';
+export * from './userJwtPayload';

--- a/backend/src/common/auth/types/userJwtPayload.ts
+++ b/backend/src/common/auth/types/userJwtPayload.ts
@@ -1,4 +1,4 @@
-export type JwtPayload = {
+export type UserJwtPayload = {
   id: number;
   intraId: string;
 };

--- a/backend/src/common/filter/http-exception.filter.ts
+++ b/backend/src/common/filter/http-exception.filter.ts
@@ -35,7 +35,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       return this.responseError(response, exception);
     }
 
-    this.logger.error('HttpException', exception);
+    this.logger.error(`HttpException ${exception.name} ${exception.stack}`);
 
     const error = new InternalServerErrorException(`Unknown Error : ${this.getErrorMessage(exception)}`);
     return this.responseError(response, error);


### PR DESCRIPTION
기존 로그인 프로세스를 전반적으로 손봤습니다.

42인증 / 로그인 을 분리했습니다. 따라서 42인증후 auth/login을 명시적으로 호출해주셔야 access_token이 세팅됩니다.
(물론 그전에 auth/register를 하셔야합니다.)

as-is
로그인/회원가입 : /auth/ft -> /auth/ft/callback -> 완료
전역 유저 정보 :  /user/me
to-be
로그인 : /auth/ft -> /auth/ft/callback -> /auth/login
회원가입 : /auth/ft -> /auth/ft/callback -> /auth/register
전역 유저 정보 : /auth/login 이나 /auth/register 의 응답으로 유저 정보가 나옴, /user/me 는 deprecate 할 예정 

왠만하면 swagger에서 설명되도록 노력했는데 이해 안되는부분 있으면 말해주세요

<img width="1475" alt="스크린샷 2023-02-17 오전 4 19 01" src="https://user-images.githubusercontent.com/46391729/219465627-9a9edb1f-4061-4c2a-baa2-a9f75d211296.png">
