### PR TITLE
Feat: 프론트 바뀐 인증과정에 대응해서 수정

### DIFF
--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -12,6 +12,9 @@ export const API = {
   // Login
   FT_AUTH: '/auth/ft',
   FT_AUTH_CALLBACK: '/auth/ft/callback',
+  FT_AUTH_RANDOM: '/auth/ft/random',
+  LOGIN: '/auth/login',
+  REGISTER: '/auth/register',
   SIGN_OUT: '/auth/signout',
 
   // User

--- a/frontend/src/pages/LoginCallbackPage/index.tsx
+++ b/frontend/src/pages/LoginCallbackPage/index.tsx
@@ -1,13 +1,19 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { ROUTE } from 'common/constants';
 import { getFtCallbackCode } from 'services';
+import { getLogin } from '../../services/getLogin';
+import { postRegister } from '../../services/postRegister';
+import { sleep } from '../../utils';
+import { getErrorMessage } from '../../utils/error';
 import { loginCallbackLogoImageStyle, loginCallbackWrapperStyle } from './LoginCallbackPage.styles';
 
+// TODO: refactor me!! - by ycha
 export const LoginCallbackPage = () => {
   const [param] = useSearchParams();
   const nav = useNavigate();
+  const [loadingMessage, setLoadingMessage] = useState<string>('');
 
   useEffect(() => {
     const code = param.get('code');
@@ -15,15 +21,48 @@ export const LoginCallbackPage = () => {
       nav(ROUTE.LOGIN);
       return;
     }
-    getFtCallbackCode(code).then(() => {
+    (async () => {
+      let ftProfile: { username: string; image_url: string };
+
+      setLoadingMessage(`42인증 시도`);
+      try {
+        ftProfile = await getFtCallbackCode(code);
+        setLoadingMessage(`42인증 완료 : ${JSON.stringify(ftProfile, null, 2)}`);
+      } catch (e: unknown) {
+        setLoadingMessage(`42인증 실패 : ${getErrorMessage(e)}`);
+        return;
+      }
+      await sleep(3000);
+
+      setLoadingMessage(`회원가입 시도`);
+      try {
+        const user = await postRegister(ftProfile.username, ftProfile.image_url);
+        setLoadingMessage(`회원가입 성공 : ${JSON.stringify(user, null, 2)}`);
+      } catch (e: unknown) {
+        setLoadingMessage(`회원가입 실패 : ${getErrorMessage(e)}`);
+      }
+      await sleep(3000);
+
+      setLoadingMessage(`로그인 시도`);
+      try {
+        const user = await getLogin();
+        // TODO: user 정보를 전역 상태로 관리하도록 리팩토링 - by ycha
+        setLoadingMessage(`로그인 성공 : ${JSON.stringify(user, null, 2)})`);
+      } catch (e: unknown) {
+        setLoadingMessage(`로그인 실패 : ${getErrorMessage(e)}`);
+        return;
+      }
+
+      await sleep(3000);
       nav(ROUTE.CHAT);
-    });
+    })();
   }, [param, nav]);
 
   return (
     <main className={loginCallbackWrapperStyle}>
       <img src="/logo.png" alt="pochitandence logo" width={280} height={80} className={loginCallbackLogoImageStyle} />
       <span>로그인 중...</span>
+      <span style={{ whiteSpace: 'pre-line' }}>{loadingMessage}</span>
     </main>
   );
 };

--- a/frontend/src/pages/LoginCallbackPage/index.tsx
+++ b/frontend/src/pages/LoginCallbackPage/index.tsx
@@ -6,8 +6,7 @@ import { getFtCallbackCode } from 'services';
 import { getLogin } from '../../services/getLogin';
 import { postRegister } from '../../services/postRegister';
 import { sleep } from '../../utils';
-import { getErrorMessage } from '../../utils/error';
-import { isFtError } from '../../utils/error/isFtError';
+import { getErrorMessage, isFtError } from '../../utils/error';
 import { loginCallbackLogoImageStyle, loginCallbackWrapperStyle } from './LoginCallbackPage.styles';
 
 // TODO: refactor me!! - by ycha

--- a/frontend/src/services/getFtCallbackCode.ts
+++ b/frontend/src/services/getFtCallbackCode.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { API } from 'common/constants';
-import { FtError, isAxiosFtErrorResponse } from '../utils/error';
+import { throwAxiosFtError } from '../utils/error/throwAxiosFtError';
 
 // TODO: refactor me!! - by ycha
 interface FtProfile {
@@ -16,11 +16,5 @@ export async function getFtCallbackCode(code: string): Promise<FtProfile> {
       withCredentials: true,
     })
     .then(({ data }) => data)
-    .catch((error: unknown) => {
-      if (isAxiosFtErrorResponse(error)) {
-        throw new FtError(error.response.data);
-      }
-
-      throw error;
-    });
+    .catch(throwAxiosFtError);
 }

--- a/frontend/src/services/getLogin.ts
+++ b/frontend/src/services/getLogin.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { API } from 'common/constants';
 import { UserInfoType } from '../types/user';
-import { FtError, isAxiosFtErrorResponse } from '../utils/error';
+import { throwAxiosFtError } from '../utils/error/throwAxiosFtError';
 
 // TODO: refactor me!! - by ycha
 export async function getLogin(): Promise<UserInfoType> {
@@ -11,11 +11,5 @@ export async function getLogin(): Promise<UserInfoType> {
       withCredentials: true,
     })
     .then(({ data }) => data)
-    .catch((error: unknown) => {
-      if (isAxiosFtErrorResponse(error)) {
-        throw new FtError(error.response.data);
-      }
-
-      throw error;
-    });
+    .catch(throwAxiosFtError);
 }

--- a/frontend/src/services/getLogin.ts
+++ b/frontend/src/services/getLogin.ts
@@ -1,18 +1,13 @@
 import axios from 'axios';
 
 import { API } from 'common/constants';
+import { UserInfoType } from '../types/user';
 import { FtError, isAxiosFtErrorResponse } from '../utils/error';
 
 // TODO: refactor me!! - by ycha
-interface FtProfile {
-  id: string;
-  username: string;
-  image_url: string;
-}
-
-export async function getFtCallbackCode(code: string): Promise<FtProfile> {
+export async function getLogin(): Promise<UserInfoType> {
   return axios
-    .get<FtProfile>(`${process.env.REACT_APP_SERVER}${API.FT_AUTH_CALLBACK}?code=${code}`, {
+    .get<UserInfoType>(`${process.env.REACT_APP_SERVER}${API.LOGIN}`, {
       withCredentials: true,
     })
     .then(({ data }) => data)

--- a/frontend/src/services/postRegister.ts
+++ b/frontend/src/services/postRegister.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { API } from 'common/constants';
 import { UserInfoType } from '../types/user';
-import { FtError, isAxiosFtErrorResponse } from '../utils/error';
+import { throwAxiosFtError } from '../utils/error/throwAxiosFtError';
 
 // TODO: refactor me!! - by ycha
 export async function postRegister(nickname: string, avatar: string): Promise<UserInfoType> {
@@ -18,11 +18,5 @@ export async function postRegister(nickname: string, avatar: string): Promise<Us
       },
     )
     .then(({ data }) => data)
-    .catch((error: unknown) => {
-      if (isAxiosFtErrorResponse(error)) {
-        throw new FtError(error.response.data);
-      }
-
-      throw error;
-    });
+    .catch(throwAxiosFtError);
 }

--- a/frontend/src/services/postRegister.ts
+++ b/frontend/src/services/postRegister.ts
@@ -1,20 +1,22 @@
 import axios from 'axios';
 
 import { API } from 'common/constants';
+import { UserInfoType } from '../types/user';
 import { FtError, isAxiosFtErrorResponse } from '../utils/error';
 
 // TODO: refactor me!! - by ycha
-interface FtProfile {
-  id: string;
-  username: string;
-  image_url: string;
-}
-
-export async function getFtCallbackCode(code: string): Promise<FtProfile> {
+export async function postRegister(nickname: string, avatar: string): Promise<UserInfoType> {
   return axios
-    .get<FtProfile>(`${process.env.REACT_APP_SERVER}${API.FT_AUTH_CALLBACK}?code=${code}`, {
-      withCredentials: true,
-    })
+    .post<UserInfoType>(
+      `${process.env.REACT_APP_SERVER}${API.REGISTER}`,
+      {
+        nickname,
+        avatar,
+      },
+      {
+        withCredentials: true,
+      },
+    )
     .then(({ data }) => data)
     .catch((error: unknown) => {
       if (isAxiosFtErrorResponse(error)) {

--- a/frontend/src/utils/error/ftError.ts
+++ b/frontend/src/utils/error/ftError.ts
@@ -1,0 +1,11 @@
+import { FtErrorResponse } from './ftErrorResponse';
+
+export class FtError extends Error {
+  statusCode: number;
+
+  constructor(errorResponse: FtErrorResponse) {
+    super(errorResponse.message);
+    this.name = `FtError(${errorResponse.error})`;
+    this.statusCode = errorResponse.statusCode;
+  }
+}

--- a/frontend/src/utils/error/ftErrorResponse.ts
+++ b/frontend/src/utils/error/ftErrorResponse.ts
@@ -1,0 +1,5 @@
+export interface FtErrorResponse {
+  error: string;
+  message: string;
+  statusCode: number;
+}

--- a/frontend/src/utils/error/getErrorMessage.ts
+++ b/frontend/src/utils/error/getErrorMessage.ts
@@ -1,0 +1,9 @@
+import { FtError } from './ftError';
+
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof FtError) {
+    return error.message;
+  }
+
+  return (error as Error).message;
+};

--- a/frontend/src/utils/error/index.ts
+++ b/frontend/src/utils/error/index.ts
@@ -1,3 +1,4 @@
 export { FtError } from './ftError';
 export { getErrorMessage } from './getErrorMessage';
 export { isAxiosFtErrorResponse } from './isAxiosFtErrorResponse';
+export { isFtError } from './isFtError';

--- a/frontend/src/utils/error/index.ts
+++ b/frontend/src/utils/error/index.ts
@@ -1,0 +1,3 @@
+export { FtError } from './ftError';
+export { getErrorMessage } from './getErrorMessage';
+export { isAxiosFtErrorResponse } from './isAxiosFtErrorResponse';

--- a/frontend/src/utils/error/isAxiosFtErrorResponse.ts
+++ b/frontend/src/utils/error/isAxiosFtErrorResponse.ts
@@ -1,0 +1,19 @@
+import { AxiosError, isAxiosError } from 'axios';
+import { FtErrorResponse } from './ftErrorResponse';
+
+export function isAxiosFtErrorResponse(error: unknown): error is AxiosError<FtErrorResponse> {
+  if (!isAxiosError(error)) {
+    return false;
+  }
+
+  if (!error.response) {
+    return false;
+  }
+
+  const { data } = error.response;
+  if (!data || !data.error || !data.message || !data.statusCode) {
+    return false;
+  }
+
+  return true;
+}

--- a/frontend/src/utils/error/isFtError.ts
+++ b/frontend/src/utils/error/isFtError.ts
@@ -1,0 +1,9 @@
+import { FtError } from './ftError';
+
+export function isFtError(error: unknown): error is FtError {
+  if (error instanceof FtError) {
+    return true;
+  }
+
+  return false;
+}

--- a/frontend/src/utils/error/throwAxiosFtError.ts
+++ b/frontend/src/utils/error/throwAxiosFtError.ts
@@ -1,0 +1,10 @@
+import { FtError } from './ftError';
+import { isAxiosFtErrorResponse } from './isAxiosFtErrorResponse';
+
+export function throwAxiosFtError(error: unknown): never {
+  if (isAxiosFtErrorResponse(error)) {
+    throw new FtError(error.response.data);
+  }
+
+  throw error;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { checkIsUserOperator } from './checkIsUserOperator';
+export { sleep } from './sleep';

--- a/frontend/src/utils/sleep.ts
+++ b/frontend/src/utils/sleep.ts
@@ -1,0 +1,4 @@
+export const sleep = (ms: number) =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });


### PR DESCRIPTION
바뀔 인증과정에 대응해서 api 쪽만 살짝 손봤습니다. 

왠만하면 프론트 손 안대려고 하는데 인증에 break change 가 너무 많아서 대강 어떤식으로 돌아가는지 이해시켜드리기 위해서 추가했습니다.

코드 퀄리티 신경안쓰고 무지성으로 돌아가게만 짰습니다. 추후에 리펙토링 부탁드립니다 🙇 


---

에러 처리 관련해서 몇가지 유틸들을 추가해보았습니다. 

제 멋대로 FtError 라는걸 하나 만들었는데, 백엔드에서 의도된 에러 내려줄때는 해당 에러로 내려주고 있습니다. 

FtError 안에 message 부분만 toast 형식으로 화면 아래 띄워보는거 어떨지 조심스레 의견 내봅니다.