### PR TITLE
feat: 등록된 유저인지 알려주도록 수정

### DIFF
--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -40,6 +40,7 @@ export class AuthController {
   ): Promise<FtProfileDto> {
     const jwt = this.cookieService.createJwt<FtProfile>(ftProfile);
     const cookieOption = this.cookieService.getCookieOption();
+    const isRegistered = await this.loginService.isRegistered(ftProfile);
 
     response.cookie('ft_profile', jwt, cookieOption);
 
@@ -47,6 +48,7 @@ export class AuthController {
       id: ftProfile.id,
       username: ftProfile.username,
       image_url: ftProfile.image_url,
+      isRegistered,
     };
   }
 
@@ -65,7 +67,7 @@ export class AuthController {
 
     response.cookie('ft_profile', jwt, cookieOption);
 
-    return ftProfile;
+    return { ...ftProfile, isRegistered: false };
   }
 
   @Get('login')

--- a/backend/src/api/auth/dto/response/ft-profile.dto.ts
+++ b/backend/src/api/auth/dto/response/ft-profile.dto.ts
@@ -12,4 +12,7 @@ export class FtProfileDto {
     description: '인트라 프로필 이미지',
   })
   image_url: string;
+
+  @ApiProperty({ example: 'false', description: '등록된 유저인지 유무' })
+  isRegistered: boolean;
 }

--- a/backend/src/api/auth/service/login.service.ts
+++ b/backend/src/api/auth/service/login.service.ts
@@ -25,6 +25,14 @@ export class LoginService {
     return user;
   }
 
+  async isRegistered(ftProfile: FtProfile): Promise<boolean> {
+    const user = await this.userRepository.findOne({
+      where: { intraId: ftProfile.id },
+    });
+
+    return !!user;
+  }
+
   async register(ftProfile: FtProfile, registerDto: RegisterRequestDto): Promise<User> {
     const alreadyRegisteredUser = await this.userRepository.findOne({
       where: { intraId: ftProfile.id },


### PR DESCRIPTION
callback으로 등록된 유저인지 알려주도록 수정했습니다.

아래와 같은 flow로 진행될 수 있습니다.
```

로그인 체크
/users/me
-> 401 인지 403인지 암튼 로그인 안되어있으면 로그인 과정으로 이동

42인증 과정
/auth/ft -> /auth/ft/callback
-> isRegistered 가 true 면 로그인과정으로
-> isRegistered 가 false 면 회원가입 과정으로

로그인 과정
/auth/login
-> 완료후 메인 페이지

회원가입 과정
/auth/register
-> 완료후 메인 페이지
```