### PR TITLE
feat: 친구 관계는 하나만 존재하도록

### DIFF
--- a/backend/src/common/database/entities/friend.entity.ts
+++ b/backend/src/common/database/entities/friend.entity.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { User } from './user.entity';
 
 enum FriendStatus {
@@ -8,6 +8,7 @@ enum FriendStatus {
 }
 
 @Entity('friend')
+@Unique(['sendFriendRequestUserId', 'recvFriendRequestUserId'])
 export class Friend {
   @ApiProperty({ example: 1, description: '친구 요청 고유번호' })
   @PrimaryGeneratedColumn()


### PR DESCRIPTION
친구 이면서 차단이면 안되기 때문에 unique를 설정했습니다.

앞으로 friend 생성할때 이미 관계까 존재하는경우에는 에러가 나니까 해당 부분 예외 처리 해주세요

예)
이미 ycha -> jasong 친구 인데 ycha -> jasong 차단 요청이 들어온경우 에러
이미 ycha -> jasong 인 값이 있으면 생성 요청 처리에 대해서 에러를 던진다