### PR TITLE
Feat/profile friend/block 친구 추가, 차단 버튼 구현

### DIFF
--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -20,4 +20,8 @@ export const API = {
   // User
   USER: '/users',
   USER_ME: '/users/me',
+
+  // Friend/Block
+  FRIEND: '/friend',
+  BLOCK: '/block',
 } as const;

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useHandleSocket } from './useHandleSocket';
 export { useGetUser } from './useGetUser';
+export { useGetUserList } from './useGetUserList';
 export { useGetCurrentChatRoom } from './useGetCurrentChatRoom';
 export { useGetCurrentGameRoom } from './useGetCurrentGameRoom';
 export { useLogout } from './useLogout';

--- a/frontend/src/hooks/useGetUser.ts
+++ b/frontend/src/hooks/useGetUser.ts
@@ -32,5 +32,5 @@ export function useGetUser(userId?: string) {
     },
   });
 
-  return { data, userId, refetch };
+  return { data, refetch };
 }

--- a/frontend/src/hooks/useGetUserList.ts
+++ b/frontend/src/hooks/useGetUserList.ts
@@ -2,20 +2,19 @@ import { getBlockList, getFriendList } from 'services';
 import { useQuery } from 'react-query';
 
 export function useGetUserList() {
-  const { data: friendList } = useQuery(['friend_list'], getFriendList, {
+  const { data: friendList = [] } = useQuery(['friend_list'], getFriendList, {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 60 * 12,
     cacheTime: 1000 * 60 * 60 * 12, // TODO: 적절한 시간으로 수정
     retry: 0,
     useErrorBoundary: true,
   });
-  const { data: blockList } = useQuery(['block_list'], getBlockList, {
+  const { data: blockList = [] } = useQuery(['block_list'], getBlockList, {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 60 * 12,
     cacheTime: 1000 * 60 * 60 * 12, // TODO: 적절한 시간으로 수정
     retry: 0,
     useErrorBoundary: true,
   });
-  console.log(friendList, blockList);
   return { friendList, blockList };
 }

--- a/frontend/src/hooks/useGetUserList.ts
+++ b/frontend/src/hooks/useGetUserList.ts
@@ -1,0 +1,20 @@
+import { getBlockList, getFriendList } from 'services';
+import { useQuery } from 'react-query';
+
+export function useGetUserList() {
+  const { data: friendList } = useQuery(['friend_list'], getFriendList, {
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 60 * 12,
+    cacheTime: 1000 * 60 * 60 * 12, // TODO: 적절한 시간으로 수정
+    retry: 0,
+    useErrorBoundary: true,
+  });
+  const { data: blockList } = useQuery(['block_list'], getBlockList, {
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 60 * 12,
+    cacheTime: 1000 * 60 * 60 * 12, // TODO: 적절한 시간으로 수정
+    retry: 0,
+    useErrorBoundary: true,
+  });
+  return { friendList, blockList };
+}

--- a/frontend/src/hooks/useGetUserList.ts
+++ b/frontend/src/hooks/useGetUserList.ts
@@ -16,5 +16,6 @@ export function useGetUserList() {
     retry: 0,
     useErrorBoundary: true,
   });
+  console.log(friendList, blockList);
   return { friendList, blockList };
 }

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,0 +1,40 @@
+// import { useState } from 'react';
+import { UserInfoType } from 'types/user';
+
+const DUMMY_FRIENDLIST: UserInfoType[] = [
+  {
+    id: 2,
+    intraId: '',
+    nickname: '',
+    avatar: '',
+    point: 0,
+    createdAt: '1970-01-01T00:00:00.000Z',
+    updatedAt: '1970-01-01T00:00:00.000Z',
+  },
+];
+
+const DUMMY_BlOCKLIST: UserInfoType[] = [
+  {
+    id: 3,
+    intraId: '',
+    nickname: '',
+    avatar: '',
+    point: 0,
+    createdAt: '1970-01-01T00:00:00.000Z',
+    updatedAt: '1970-01-01T00:00:00.000Z',
+  },
+];
+
+export const ManageFriends = ({ user }: { user: UserInfoType }) => {
+  return (
+    <div>
+      <button type="button"> Unfriend</button>
+      <br />
+      <button type="button">Add Friend</button>
+      <br />
+      <button type="button">Block</button>
+      <br />
+      <button type="button">Unblock</button>
+    </div>
+  );
+};

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,4 +1,3 @@
-// import { useState } from 'react';
 import { UserInfoType } from 'types/user';
 
 const DUMMY_FRIENDLIST: UserInfoType[] = [

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,40 +1,49 @@
-import { useGetUser } from 'hooks';
+// import { useGetUser } from 'hooks';
 import { UserInfoType } from 'types/user';
 
-const DUMMY_FRIENDLIST: UserInfoType[] = [
-  {
-    id: -1,
-    intraId: '',
-    nickname: '',
-    avatar: '',
-    point: 0,
-    createdAt: '1970-01-01T00:00:00.000Z',
-    updatedAt: '1970-01-01T00:00:00.000Z',
-  },
-];
+// const DUMMY_FRIENDLIST: UserInfoType[] = [
+//   {
+//     id: -1,
+//     intraId: '',
+//     nickname: '',
+//     avatar: '',
+//     point: 0,
+//     createdAt: '1970-01-01T00:00:00.000Z',
+//     updatedAt: '1970-01-01T00:00:00.000Z',
+//   },
+// ];
 
-const DUMMY_BLOCKLIST: UserInfoType[] = [
-  {
-    id: -1,
-    intraId: '',
-    nickname: '',
-    avatar: '',
-    point: 0,
-    createdAt: '1970-01-01T00:00:00.000Z',
-    updatedAt: '1970-01-01T00:00:00.000Z',
-  },
-];
+// const DUMMY_BLOCKLIST: UserInfoType[] = [
+//   {
+//     id: -1,
+//     intraId: '',
+//     nickname: '',
+//     avatar: '',
+//     point: 0,
+//     createdAt: '1970-01-01T00:00:00.000Z',
+//     updatedAt: '1970-01-01T00:00:00.000Z',
+//   },
+// ];
 
 type UserState = 'Friend' | 'No' | 'Block';
 
 export const ManageFriends = ({ user }: { user: UserInfoType }) => {
+  //   function classifyFriend(): UserState {
+  //     if (DUMMY_FRIENDLIST.includes(user)) return 'Friend';
+  //     if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
+  //     return 'No';
+  //   }
+  //   DUMMY_FRIENDLIST.push(useGetUser('2').data);
+  //   DUMMY_BLOCKLIST.push(useGetUser('3').data);
+
   function classifyFriend(): UserState {
     if (DUMMY_FRIENDLIST.includes(user)) return 'Friend';
     if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
     return 'No';
   }
-  DUMMY_FRIENDLIST.push(useGetUser('2').data);
-  DUMMY_BLOCKLIST.push(useGetUser('3').data);
+
+  const friendList: UserInfoType[] =
+
   const isFriend: UserState = classifyFriend();
   return (
     <div>

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -18,16 +18,16 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
     return 'No';
   }
 
-  const isFriend: UserState = classifyFriend();
+  const friendState: UserState = classifyFriend();
   return (
     <div>
-      {isFriend === 'Friend' && (
+      {friendState === 'Friend' && (
         <>
           <button type="button"> Unfriend</button>
           <br />
         </>
       )}
-      {isFriend === 'No' && (
+      {friendState === 'No' && (
         <>
           <button type="button">Add Friend</button>
           <br />
@@ -35,7 +35,7 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
           <br />
         </>
       )}
-      {isFriend === 'Block' && (
+      {friendState === 'Block' && (
         <>
           <button type="button">Unblock</button>
           <br />

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,8 +1,9 @@
+import { useGetUser } from 'hooks';
 import { UserInfoType } from 'types/user';
 
 const DUMMY_FRIENDLIST: UserInfoType[] = [
   {
-    id: 2,
+    id: -1,
     intraId: '',
     nickname: '',
     avatar: '',
@@ -14,7 +15,7 @@ const DUMMY_FRIENDLIST: UserInfoType[] = [
 
 const DUMMY_BLOCKLIST: UserInfoType[] = [
   {
-    id: 3,
+    id: -1,
     intraId: '',
     nickname: '',
     avatar: '',
@@ -27,11 +28,15 @@ const DUMMY_BLOCKLIST: UserInfoType[] = [
 type UserState = 'Friend' | 'No' | 'Block';
 
 export const ManageFriends = ({ user }: { user: UserInfoType }) => {
-  const classifyFriend = (): UserState => {
+  function classifyFriend(): UserState {
     if (DUMMY_FRIENDLIST.includes(user)) return 'Friend';
     if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
     return 'No';
-  };
+  }
+  const { data } = useGetUser('2');
+  const { data: data2 } = useGetUser('3');
+  DUMMY_FRIENDLIST.push(data);
+  DUMMY_BLOCKLIST.push(data2);
   const isFriend: UserState = classifyFriend();
   return (
     <div>

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -37,14 +37,15 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
   //   DUMMY_FRIENDLIST.push(useGetUser('2').data);
   //   DUMMY_BLOCKLIST.push(useGetUser('3').data);
 
-  function classifyFriend(friendList: UserInfoType[], blockList: UserInfoType[]): UserState {
+  const { friendList, blockList } = useGetUserList();
+
+  function classifyFriend(): UserState {
     if (friendList.includes(user)) return 'Friend';
     if (blockList.includes(user)) return 'Block';
     return 'No';
   }
 
-  const { friendList, blockList } = useGetUserList();
-  const isFriend: UserState = classifyFriend(friendList, blockList);
+  const isFriend: UserState = classifyFriend();
   return (
     <div>
       {isFriend === 'Friend' && (

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -13,7 +13,7 @@ const DUMMY_FRIENDLIST: UserInfoType[] = [
   },
 ];
 
-const DUMMY_BlOCKLIST: UserInfoType[] = [
+const DUMMY_BLOCKLIST: UserInfoType[] = [
   {
     id: 3,
     intraId: '',
@@ -25,16 +25,37 @@ const DUMMY_BlOCKLIST: UserInfoType[] = [
   },
 ];
 
+type UserState = 'Friend' | 'No' | 'Block';
+
 export const ManageFriends = ({ user }: { user: UserInfoType }) => {
+  const classifyFriend = (): UserState => {
+    if (DUMMY_FRIENDLIST.includes(user)) return 'Friend';
+    if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
+    return 'No';
+  };
+  const isFriend: UserState = classifyFriend();
   return (
     <div>
-      <button type="button"> Unfriend</button>
-      <br />
-      <button type="button">Add Friend</button>
-      <br />
-      <button type="button">Block</button>
-      <br />
-      <button type="button">Unblock</button>
+      {isFriend === 'Friend' && (
+        <>
+          <button type="button"> Unfriend</button>
+          <br />
+        </>
+      )}
+      {isFriend === 'No' && (
+        <>
+          <button type="button">Add Friend</button>
+          <br />
+          <button type="button">Block</button>
+          <br />
+        </>
+      )}
+      {isFriend === 'Block' && (
+        <>
+          <button type="button">Unblock</button>
+          <br />
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,4 +1,5 @@
 // import { useGetUser } from 'hooks';
+import { useGetUserList } from 'hooks';
 import { UserInfoType } from 'types/user';
 
 // const DUMMY_FRIENDLIST: UserInfoType[] = [
@@ -36,15 +37,14 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
   //   DUMMY_FRIENDLIST.push(useGetUser('2').data);
   //   DUMMY_BLOCKLIST.push(useGetUser('3').data);
 
-  function classifyFriend(): UserState {
-    if (DUMMY_FRIENDLIST.includes(user)) return 'Friend';
-    if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
+  function classifyFriend(friendList: UserInfoType[], blockList: UserInfoType[]): UserState {
+    if (friendList.includes(user)) return 'Friend';
+    if (blockList.includes(user)) return 'Block';
     return 'No';
   }
 
-  const friendList: UserInfoType[] =
-
-  const isFriend: UserState = classifyFriend();
+  const { friendList, blockList } = useGetUserList();
+  const isFriend: UserState = classifyFriend(friendList, blockList);
   return (
     <div>
       {isFriend === 'Friend' && (

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -33,10 +33,8 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
     if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
     return 'No';
   }
-  const { data } = useGetUser('2');
-  const { data: data2 } = useGetUser('3');
-  DUMMY_FRIENDLIST.push(data);
-  DUMMY_BLOCKLIST.push(data2);
+  DUMMY_FRIENDLIST.push(useGetUser('2').data);
+  DUMMY_BLOCKLIST.push(useGetUser('3').data);
   const isFriend: UserState = classifyFriend();
   return (
     <div>

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,47 +1,20 @@
-// import { useGetUser } from 'hooks';
 import { useGetUserList } from 'hooks';
 import { UserInfoType } from 'types/user';
-
-// const DUMMY_FRIENDLIST: UserInfoType[] = [
-//   {
-//     id: -1,
-//     intraId: '',
-//     nickname: '',
-//     avatar: '',
-//     point: 0,
-//     createdAt: '1970-01-01T00:00:00.000Z',
-//     updatedAt: '1970-01-01T00:00:00.000Z',
-//   },
-// ];
-
-// const DUMMY_BLOCKLIST: UserInfoType[] = [
-//   {
-//     id: -1,
-//     intraId: '',
-//     nickname: '',
-//     avatar: '',
-//     point: 0,
-//     createdAt: '1970-01-01T00:00:00.000Z',
-//     updatedAt: '1970-01-01T00:00:00.000Z',
-//   },
-// ];
 
 type UserState = 'Friend' | 'No' | 'Block';
 
 export const ManageFriends = ({ user }: { user: UserInfoType }) => {
-  //   function classifyFriend(): UserState {
-  //     if (DUMMY_FRIENDLIST.includes(user)) return 'Friend';
-  //     if (DUMMY_BLOCKLIST.includes(user)) return 'Block';
-  //     return 'No';
-  //   }
-  //   DUMMY_FRIENDLIST.push(useGetUser('2').data);
-  //   DUMMY_BLOCKLIST.push(useGetUser('3').data);
-
   const { friendList, blockList } = useGetUserList();
 
+  function checkFriend(userList: UserInfoType): Boolean {
+    return user.id === userList.id;
+  }
+
   function classifyFriend(): UserState {
-    if (friendList.includes(user)) return 'Friend';
-    if (blockList.includes(user)) return 'Block';
+    if (friendList.some(checkFriend)) {
+      return 'Friend';
+    }
+    if (blockList.some(checkFriend)) return 'Block';
     return 'No';
   }
 

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -6,6 +6,7 @@ import { useGetUser } from 'hooks';
 
 import { ProfileCard } from './ProfileCard';
 import { EditProfile } from './EditProfile';
+import { ManageFriends } from './ManageFriends';
 
 export const ProfilePage = () => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
@@ -31,6 +32,7 @@ export const ProfilePage = () => {
             Edit Profile
           </button>
         )}
+        {userId && <ManageFriends user={profile} />}
       </main>
       {isModalShown && (
         <Modal onClickClose={handleCloseModal}>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -11,7 +11,7 @@ import { ManageFriends } from './ManageFriends';
 export const ProfilePage = () => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
   const { id } = useParams();
-  const { data: profile, userId } = useGetUser(id);
+  const { data: profile } = useGetUser(id);
 
   function handleOpenModal() {
     setModalShown(true);
@@ -27,12 +27,12 @@ export const ProfilePage = () => {
       <main>
         <h1>Profile Page</h1>
         <ProfileCard user={profile} />
-        {!userId && (
+        {!id && (
           <button type="button" onClick={handleOpenModal}>
             Edit Profile
           </button>
         )}
-        {userId && <ManageFriends user={profile} />}
+        {id && <ManageFriends user={profile} />}
       </main>
       {isModalShown && (
         <Modal onClickClose={handleCloseModal}>

--- a/frontend/src/services/getBlockList.ts
+++ b/frontend/src/services/getBlockList.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { API } from 'common/constants';
+import { UserInfoType } from 'types/user';
+import { throwApiError } from 'utils/error';
+
+export function getBlockList(): Promise<UserInfoType[]> {
+  return axios
+    .get<UserInfoType[]>(`${process.env.REACT_APP_SERVER}${API.BLOCK}`, {
+      withCredentials: true,
+    })
+    .then(({ data }) => data)
+    .catch(throwApiError);
+}

--- a/frontend/src/services/getBlockList.ts
+++ b/frontend/src/services/getBlockList.ts
@@ -6,7 +6,7 @@ import { throwApiError } from 'utils/error';
 
 export function getBlockList(): Promise<UserInfoType[]> {
   return axios
-    .get<UserInfoType[]>(`${process.env.REACT_APP_SERVER}${API.BLOCK}`, {
+    .get<UserInfoType[]>(`${process.env.REACT_APP_SERVER}${API.FRIEND}${API.BLOCK}`, {
       withCredentials: true,
     })
     .then(({ data }) => data)

--- a/frontend/src/services/getFriendList.ts
+++ b/frontend/src/services/getFriendList.ts
@@ -4,7 +4,7 @@ import { API } from 'common/constants';
 import { UserInfoType } from 'types/user';
 import { throwApiError } from 'utils/error';
 
-export function getFriendList(): Promise<UserInfoType[]> {
+export async function getFriendList(): Promise<UserInfoType[]> {
   return axios
     .get<UserInfoType[]>(`${process.env.REACT_APP_SERVER}${API.FRIEND}`, {
       withCredentials: true,

--- a/frontend/src/services/getFriendList.ts
+++ b/frontend/src/services/getFriendList.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { API } from 'common/constants';
+import { UserInfoType } from 'types/user';
+import { throwApiError } from 'utils/error';
+
+export function getFriendList(): Promise<UserInfoType[]> {
+  return axios
+    .get<UserInfoType[]>(`${process.env.REACT_APP_SERVER}${API.FRIEND}`, {
+      withCredentials: true,
+    })
+    .then(({ data }) => data)
+    .catch(throwApiError);
+}

--- a/frontend/src/services/getUserInfo.ts
+++ b/frontend/src/services/getUserInfo.ts
@@ -8,7 +8,7 @@ interface Props {
   userId?: string;
 }
 
-export function getUserInfo({ userId }: Props): Promise<UserInfoType> {
+export async function getUserInfo({ userId }: Props): Promise<UserInfoType> {
   return axios
     .get<UserInfoType>(`${process.env.REACT_APP_SERVER}${userId ? `${API.USER}/${userId}` : API.USER_ME}`, {
       withCredentials: true,

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -2,3 +2,5 @@ export { getUserInfo } from './getUserInfo';
 export { getFtCallbackCode } from './getFtCallbackCode';
 export { putUserProfile } from './putUserProfile';
 export { deleteAuthSignout } from './deleteAuthSignout';
+export { getFriendList } from './getFriendList';
+export { getBlockList } from './getBlockList';


### PR DESCRIPTION
- fix #113 
- fix #78

버튼 눌러도 아무일도 안일어납니다 !

@ft-jasong 이 완성한 GET friend, friend/block API 이용하는 걸로 수정 완료 !

GET friend, GET friend/block API 를 호출해서 친구/차단 리스트를 받아오고,
profile/{id} 페이지에서 타겟의 상태(친구/친구아님/차단) 에 따라서 보여주는 버튼이 다르게 하는 것 까지 구현했습니다.

버튼을 눌렀을 때 친구가 추가되고 차단되는 기능은 다음 PR 에서 구현하겠습니다 !

테스트는 incognito tab 에서 랜덤 계정을 만들어서, docs 에서 친구/차단 하면서 테스트 했습니다.

![Screenshot from 2023-02-20 15-47-16](https://user-images.githubusercontent.com/62825700/220033249-19eef2ca-e307-4e69-ae04-ef10cdda0b58.png)
1. 랜덤 유저 (id: 2) 를 생성한 뒤, 친구 추가

![Screenshot from 2023-02-20 15-47-56](https://user-images.githubusercontent.com/62825700/220033310-22ce68f3-45d1-4903-bd4f-ca0501a27f30.png)
2. 친구 추가가 된 것을 확인 ( Unfriend 버튼이 생김 )

Unfriend, Block 도 동일한 방식으로 테스트 완료, 잘 작동되는 것 확인 !