### PR TITLE
Pong: Host 체크 기능 추가

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -3,3 +3,4 @@ export { useGetUser } from './useGetUser';
 export { useGetCurrentChatRoom } from './useGetCurrentChatRoom';
 export { useGetCurrentGameRoom } from './useGetCurrentGameRoom';
 export { useLogout } from './useLogout';
+export { sockets } from './useHandleSocket';

--- a/frontend/src/pages/GamePage/MainScene.tsx
+++ b/frontend/src/pages/GamePage/MainScene.tsx
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
 import { GameData } from 'types/game';
 
-import { sockets } from '../../hooks/useHandleSocket';
+import { sockets } from 'hooks';
 
 const scoreFontStyle = { fontSize: '32px', fontFamily: 'Arial' };
 export class MainScene extends Phaser.Scene {

--- a/frontend/src/pages/GamePage/MainScene.tsx
+++ b/frontend/src/pages/GamePage/MainScene.tsx
@@ -5,6 +5,7 @@ import { sockets } from 'hooks';
 
 const scoreFontStyle = { fontSize: '32px', fontFamily: 'Arial' };
 export class MainScene extends Phaser.Scene {
+  private isHost: Boolean;
   private ball: Phaser.Physics.Arcade.Image;
   private paddleLeft: Phaser.Physics.Arcade.Image;
   private paddleRight: Phaser.Physics.Arcade.Image;
@@ -27,6 +28,10 @@ export class MainScene extends Phaser.Scene {
 
   initHandlers() {
     sockets.gameSocket.on('game_data', this.gameDataHandler.bind(this));
+  }
+
+  hostCheckHandlers(isHostInput: boolean) {
+    this.isHost = isHostInput;
   }
 
   preload() {
@@ -76,11 +81,13 @@ export class MainScene extends Phaser.Scene {
 
     if (!this.paddleLeft || !this.paddleRight || !this.key) return;
 
-    if (this.key.up.isDown) this.paddleRight.y -= 10;
-    else if (this.key.down.isDown) this.paddleRight.y += 10;
-
-    if (this.key.shift.isDown) this.paddleLeft.y -= 10;
-    else if (this.key.space.isDown) this.paddleLeft.y += 10;
+    if (this.isHost) {
+      if (this.key.up.isDown) this.paddleLeft.y -= 10;
+      else if (this.key.down.isDown) this.paddleLeft.y += 10;
+    } else if (!this.isHost) {
+      if (this.key.up.isDown) this.paddleRight.y -= 10;
+      else if (this.key.down.isDown) this.paddleRight.y += 10;
+    }
 
     /* Paddle 임시 충돌 판정 코드 */
     this.paddleLeft.y = Phaser.Math.Clamp(this.paddleLeft.y, 50, 550);
@@ -98,24 +105,26 @@ export class MainScene extends Phaser.Scene {
       this.initBall();
     }
 
-    // send paddle position (challenger)
-    if (this.key.up.isDown || this.key.down.isDown) {
-      sockets.gameSocket.emit('update_position', {
-        paddleY: this.paddleRight.y, //
-      });
-    }
-
-    // send paddle position (host)
-    if (this.key.shift.isDown || this.key.space.isDown) {
-      sockets.gameSocket.emit('update_position', {
-        paddleY: this.paddleLeft.y, //
-        ball: {
-          x: this.ball.x,
-          y: this.ball.y,
-          velocityX: this.ball.body.velocity.x,
-          velocityY: this.ball.body.velocity.y,
-        },
-      });
+    if (this.isHost) {
+      // send paddle position (host)
+      if (this.key.up.isDown || this.key.down.isDown) {
+        sockets.gameSocket.emit('update_position', {
+          paddleY: this.paddleLeft.y, //
+          ball: {
+            x: this.ball.x,
+            y: this.ball.y,
+            velocityX: this.ball.body.velocity.x,
+            velocityY: this.ball.body.velocity.y,
+          },
+        });
+      }
+    } else if (!this.isHost) {
+      // send paddle position (challenger)
+      if (this.key.up.isDown || this.key.down.isDown) {
+        sockets.gameSocket.emit('update_position', {
+          paddleY: this.paddleRight.y, //
+        });
+      }
     }
 
     // restore paddle position
@@ -128,7 +137,7 @@ export class MainScene extends Phaser.Scene {
     if (data.challenger) this.paddleRight.y = data.challenger.y;
 
     // temperary check if player is challenger
-    if (!this.key.shift.isDown && !this.key.space.isDown) {
+    if (!this.key.up.isDown && !this.key.down.isDown) {
       if (data.ball) {
         this.ball.setPosition(data.ball.x, data.ball.y);
         this.ball.setVelocity(data.ball.velocityX, data.ball.velocityY);

--- a/frontend/src/pages/GamePage/game.tsx
+++ b/frontend/src/pages/GamePage/game.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from 'react';
 import Phaser from 'phaser';
 import { GameInstance, IonPhaser } from '@ion-phaser/react';
 
+import { useGetCurrentGameRoom, useGetUser } from 'hooks';
 import { MainScene } from './MainScene';
 
 const mainScene = new MainScene();
@@ -19,7 +20,13 @@ const GamePong = () => {
   const gameRef = useRef<HTMLIonPhaserElement>(null);
   const [initialize] = useState(true);
 
+  const { data: currentUser } = useGetUser();
+  const currentGameRoom = useGetCurrentGameRoom();
+
+  const isHost = currentUser.id === currentGameRoom.host.user.id;
+
   mainScene.initHandlers();
+  mainScene.hostCheckHandlers(isHost);
 
   return <IonPhaser ref={gameRef} game={game} initialize={initialize} />;
 };

--- a/frontend/src/pages/GamePage/game.tsx
+++ b/frontend/src/pages/GamePage/game.tsx
@@ -1,6 +1,7 @@
-import { GameInstance, IonPhaser } from '@ion-phaser/react';
-import Phaser from 'phaser';
 import { useRef, useState } from 'react';
+
+import Phaser from 'phaser';
+import { GameInstance, IonPhaser } from '@ion-phaser/react';
 
 import { MainScene } from './MainScene';
 

--- a/frontend/src/pages/GamePage/index.tsx
+++ b/frontend/src/pages/GamePage/index.tsx
@@ -1,5 +1,6 @@
-import { useGetCurrentGameRoom } from 'hooks';
 import { useEffect } from 'react';
+
+import { useGetCurrentGameRoom } from 'hooks';
 import { useSetRecoilState } from 'recoil';
 import { leaveGameRoomState } from 'store';
 import GamePong from './game';
@@ -7,7 +8,6 @@ import GamePong from './game';
 export const GamePage = () => {
   const currentGameRoom = useGetCurrentGameRoom();
   const setLeaveGameRoom = useSetRecoilState(leaveGameRoomState);
-
   useEffect(() => {
     return () => {
       setLeaveGameRoom({ id: currentGameRoom.id });
@@ -18,8 +18,8 @@ export const GamePage = () => {
     <div>
       <GamePong />
       {/* 게임 설명 예시 */}
-      <div>•BALL WILL SERVE AUTOMATICALLY</div>
-      <div>•AVOID MISSING BALL FOR HIGH SCORE</div>
+      <div>• BALL WILL SERVE AUTOMATICALLY</div>
+      <div>• AVOID MISSING BALL FOR HIGH SCORE</div>
     </div>
   );
 };

--- a/frontend/src/types/game.d.ts
+++ b/frontend/src/types/game.d.ts
@@ -1,6 +1,6 @@
 import { UserInfoType } from './user';
 
-type PlayerDetail = {
+type Player = {
   user: UserInfoType;
   ready: boolean;
 };
@@ -13,8 +13,8 @@ type Score = {
 export interface GameRoomInfoType {
   id: string;
   state: 'waiting' | 'playing' | 'finished';
-  host: PlayerDetail;
-  challenger?: PlayerDetail;
+  host: Player;
+  challenger?: Player;
   spectatorSocketIds: Set<string>;
   score: Score;
 }


### PR DESCRIPTION
추가된 기능
---
 1. 게임에 들어온 Player가 Host인지 체크
 2. Host인지 체크하여 자신의 Paddle만 방향키로 조작 가능(Host 왼쪽, Challenger 오른쪽)
 3. Host 판별하여 보낼 데이터만 보냄

너무 많이 위치를 갱신하는 최적화 이슈가 있음 → Ball hit시에만 데이터를 주고 받는 방향으로 최적화 가능해 보임