### PR TITLE
Feat/profile manage buttons

### DIFF
--- a/frontend/src/hooks/useGetUserList.ts
+++ b/frontend/src/hooks/useGetUserList.ts
@@ -2,19 +2,19 @@ import { getBlockList, getFriendList } from 'services';
 import { useQuery } from 'react-query';
 
 export function useGetUserList() {
-  const { data: friendList = [] } = useQuery(['friend_list'], getFriendList, {
+  const { data: friendList = [], refetch: refetchFriendList } = useQuery(['friend_list'], getFriendList, {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 60 * 12,
     cacheTime: 1000 * 60 * 60 * 12, // TODO: 적절한 시간으로 수정
     retry: 0,
     useErrorBoundary: true,
   });
-  const { data: blockList = [] } = useQuery(['block_list'], getBlockList, {
+  const { data: blockList = [], refetch: refetchBlockList } = useQuery(['block_list'], getBlockList, {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 60 * 12,
     cacheTime: 1000 * 60 * 60 * 12, // TODO: 적절한 시간으로 수정
     retry: 0,
     useErrorBoundary: true,
   });
-  return { friendList, blockList };
+  return { friendList, blockList, refetchFriendList, refetchBlockList };
 }

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -6,16 +6,14 @@ import { UserInfoType } from 'types/user';
 type UserState = 'Friend' | 'No' | 'Block';
 
 export const ManageFriends = ({ user }: { user: UserInfoType }) => {
-  const { friendList, blockList } = useGetUserList();
+  const { friendList, blockList, refetchFriendList, refetchBlockList } = useGetUserList();
 
   function checkFriend(userList: UserInfoType): Boolean {
     return user.id === userList.id;
   }
 
   function classifyFriend(): UserState {
-    if (friendList.some(checkFriend)) {
-      return 'Friend';
-    }
+    if (friendList.some(checkFriend)) return 'Friend';
     if (blockList.some(checkFriend)) return 'Block';
     return 'No';
   }
@@ -23,11 +21,17 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
   const friendState: UserState = classifyFriend();
 
   function handleClickUnfriendOrBlock() {
-    deleteFriend(user.id);
+    deleteFriend(user.id).then(() => {
+      refetchFriendList();
+      refetchBlockList();
+    });
   }
 
   function handleClickFriendOrBlock(userID: number, status: 'FRIEND' | 'BLOCK') {
-    postFriendOrBlock({ recvFriendRequestUserId: userID, status });
+    postFriendOrBlock({ recvFriendRequestUserId: userID, status }).then(() => {
+      refetchFriendList();
+      refetchBlockList();
+    });
   }
 
   return (

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -1,4 +1,6 @@
 import { useGetUserList } from 'hooks';
+import { deleteFriend } from 'services/deleteFriend';
+import { postFriendOrBlock } from 'services/postFriendOrBlock';
 import { UserInfoType } from 'types/user';
 
 type UserState = 'Friend' | 'No' | 'Block';
@@ -19,25 +21,42 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
   }
 
   const friendState: UserState = classifyFriend();
+
+  function handleClickUnfriendOrBlock() {
+    deleteFriend(user.id);
+  }
+
+  function handleClickFriendOrBlock(userID: number, state: 'FRIEND' | 'BLOCK') {
+    postFriendOrBlock({ recvFriendRequestUserId: userID, state });
+  }
+
   return (
     <div>
       {friendState === 'Friend' && (
         <>
-          <button type="button"> Unfriend</button>
+          <button type="button" onClick={handleClickUnfriendOrBlock}>
+            Unfriend
+          </button>
           <br />
         </>
       )}
       {friendState === 'No' && (
         <>
-          <button type="button">Add Friend</button>
+          <button type="button" onClick={() => handleClickFriendOrBlock(user.id, 'FRIEND')}>
+            Add Friend
+          </button>
           <br />
-          <button type="button">Block</button>
+          <button type="button" onClick={() => handleClickFriendOrBlock(user.id, 'BLOCK')}>
+            Block
+          </button>
           <br />
         </>
       )}
       {friendState === 'Block' && (
         <>
-          <button type="button">Unblock</button>
+          <button type="button" onClick={handleClickUnfriendOrBlock}>
+            Unblock
+          </button>
           <br />
         </>
       )}

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -26,8 +26,8 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
     deleteFriend(user.id);
   }
 
-  function handleClickFriendOrBlock(userID: number, state: 'FRIEND' | 'BLOCK') {
-    postFriendOrBlock({ recvFriendRequestUserId: userID, state });
+  function handleClickFriendOrBlock(userID: number, status: 'FRIEND' | 'BLOCK') {
+    postFriendOrBlock({ recvFriendRequestUserId: userID, status });
   }
 
   return (

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -12,6 +12,7 @@ export const ProfilePage = () => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
   const { id } = useParams();
   const { data: profile } = useGetUser(id);
+  const { data: myProfile } = useGetUser();
 
   function handleOpenModal() {
     setModalShown(true);
@@ -27,12 +28,12 @@ export const ProfilePage = () => {
       <main>
         <h1>Profile Page</h1>
         <ProfileCard user={profile} />
-        {!id && (
+        {(!id || profile.id === myProfile.id) && (
           <button type="button" onClick={handleOpenModal}>
             Edit Profile
           </button>
         )}
-        {id && <ManageFriends user={profile} />}
+        {!(!id || profile.id === myProfile.id) && <ManageFriends user={profile} />}
       </main>
       {isModalShown && (
         <Modal onClickClose={handleCloseModal}>

--- a/frontend/src/services/deleteFriend.ts
+++ b/frontend/src/services/deleteFriend.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+import { API } from 'common/constants';
+
+export function deleteFriend(recvFriendRequestUserId: number): Promise<void> {
+  return axios.delete(`${process.env.REACT_APP_SERVER}${API.FRIEND}`, {
+    data: { recvFriendRequestUserId },
+    withCredentials: true,
+  });
+}

--- a/frontend/src/services/postFriendOrBlock.ts
+++ b/frontend/src/services/postFriendOrBlock.ts
@@ -4,13 +4,13 @@ import { API } from 'common/constants';
 
 interface Props {
   recvFriendRequestUserId: number;
-  state: 'FRIEND' | 'BLOCK';
+  status: 'FRIEND' | 'BLOCK';
 }
 
-export function postFriendOrBlock({ recvFriendRequestUserId, state }: Props): Promise<void> {
+export function postFriendOrBlock({ recvFriendRequestUserId, status }: Props): Promise<void> {
   return axios.post(
     `${process.env.REACT_APP_SERVER}${API.FRIEND}`,
-    { recvFriendRequestUserId, state },
+    { recvFriendRequestUserId, status },
     {
       withCredentials: true,
     },

--- a/frontend/src/services/postFriendOrBlock.ts
+++ b/frontend/src/services/postFriendOrBlock.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+import { API } from 'common/constants';
+
+interface Props {
+  recvFriendRequestUserId: number;
+  state: 'FRIEND' | 'BLOCK';
+}
+
+export function postFriendOrBlock({ recvFriendRequestUserId, state }: Props): Promise<void> {
+  return axios.post(
+    `${process.env.REACT_APP_SERVER}${API.FRIEND}`,
+    { recvFriendRequestUserId, state },
+    {
+      withCredentials: true,
+    },
+  );
+}


### PR DESCRIPTION
- fix #124 

1. POST, DELETE /friend API 를 적용해서, 친구 추가/ 차단 버튼이 실제로 서버와 대응되도록 구현했습니다 !

2. /profile/{본인 아이디} 로 리다이렉션 할 경우 본인 프로필에 친구 추가/ 차단 버튼이 뜨는 문제를 수정했습니다 !
(이제는 본인 아이디의 페이지로 이동 시, 친구 추가/차단 버튼 대신 프로필 수정 버튼이 뜸)
ex) 내 아이디가 1임
- /profile 과 /profile/1 이 동일한 컴포넌트를 보여줌.