### PR TITLE
Style/profile 프로필 페이지 기본적인 레이아웃 추가 !

### DIFF
--- a/frontend/src/pages/ProfilePage/Achievement/AchievementList.tsx
+++ b/frontend/src/pages/ProfilePage/Achievement/AchievementList.tsx
@@ -25,12 +25,12 @@ const DUMMY_ACHIEVEMENT = [
 
 export const AchievementList = ({ userId, className }: Props) => {
   return (
-    <main className={className}>
+    <div className={className}>
       <h1>Achievement</h1>
       <h2> debug: ID : {userId}</h2>
       {DUMMY_ACHIEVEMENT.map((value: AchievementType) => (
         <Achievement key={value.id} achieve={value} />
       ))}
-    </main>
+    </div>
   );
 };

--- a/frontend/src/pages/ProfilePage/Achievement/AchievementList.tsx
+++ b/frontend/src/pages/ProfilePage/Achievement/AchievementList.tsx
@@ -3,6 +3,7 @@ import { Achievement } from './Achievement';
 
 interface Props {
   userId: number;
+  className?: string;
 }
 
 const DUMMY_ACHIEVEMENT = [
@@ -22,9 +23,9 @@ const DUMMY_ACHIEVEMENT = [
   },
 ];
 
-export const AchievementList = ({ userId }: Props) => {
+export const AchievementList = ({ userId, className }: Props) => {
   return (
-    <main>
+    <main className={className}>
       <h1>Achievement</h1>
       <h2> debug: ID : {userId}</h2>
       {DUMMY_ACHIEVEMENT.map((value: AchievementType) => (

--- a/frontend/src/pages/ProfilePage/EditProfile.tsx
+++ b/frontend/src/pages/ProfilePage/EditProfile.tsx
@@ -8,9 +8,10 @@ import { EditProfileModal } from './EditProfileModal';
 interface Props {
   user: UserInfoType;
   refetch: () => void;
+  className?: string;
 }
 
-export const EditProfile = ({ user, refetch }: Props) => {
+export const EditProfile = ({ user, refetch, className }: Props) => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
 
   function handleOpenModal() {
@@ -23,7 +24,7 @@ export const EditProfile = ({ user, refetch }: Props) => {
 
   return (
     <>
-      <div>
+      <div className={className}>
         <button type="button" onClick={handleOpenModal}>
           Edit Profile
         </button>

--- a/frontend/src/pages/ProfilePage/EditProfile.tsx
+++ b/frontend/src/pages/ProfilePage/EditProfile.tsx
@@ -4,6 +4,7 @@ import { Modal } from 'common';
 import { UserInfoType } from 'types/user';
 
 import { EditProfileModal } from './EditProfileModal';
+import { editProfileButtonStyle } from './ProfileCard.style';
 
 interface Props {
   user: UserInfoType;
@@ -23,7 +24,7 @@ export const EditProfile = ({ user, refetch }: Props) => {
 
   return (
     <>
-      <div>
+      <div className={editProfileButtonStyle}>
         <button type="button" onClick={handleOpenModal}>
           Edit Profile
         </button>

--- a/frontend/src/pages/ProfilePage/EditProfile.tsx
+++ b/frontend/src/pages/ProfilePage/EditProfile.tsx
@@ -8,10 +8,9 @@ import { EditProfileModal } from './EditProfileModal';
 interface Props {
   user: UserInfoType;
   refetch: () => void;
-  className?: string;
 }
 
-export const EditProfile = ({ user, refetch, className }: Props) => {
+export const EditProfile = ({ user, refetch }: Props) => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
 
   function handleOpenModal() {
@@ -24,7 +23,7 @@ export const EditProfile = ({ user, refetch, className }: Props) => {
 
   return (
     <>
-      <div className={className}>
+      <div>
         <button type="button" onClick={handleOpenModal}>
           Edit Profile
         </button>

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -5,7 +5,12 @@ import { UserInfoType } from 'types/user';
 
 type UserState = 'Friend' | 'No' | 'Block';
 
-export const ManageFriends = ({ user }: { user: UserInfoType }) => {
+interface Props {
+  user: UserInfoType;
+  className?: string;
+}
+
+export const ManageFriends = ({ user, className }: Props) => {
   const { friendList, refetch: refetchFriendList } = useGetFriendList();
   const { blockList, refetch: refetchBlockList } = useGetBlockList();
 
@@ -36,7 +41,7 @@ export const ManageFriends = ({ user }: { user: UserInfoType }) => {
   }
 
   return (
-    <div>
+    <div className={className}>
       {friendState === 'Friend' && (
         <>
           <button type="button" onClick={handleClickUnfriendOrBlock}>

--- a/frontend/src/pages/ProfilePage/ManageFriends.tsx
+++ b/frontend/src/pages/ProfilePage/ManageFriends.tsx
@@ -5,12 +5,7 @@ import { UserInfoType } from 'types/user';
 
 type UserState = 'Friend' | 'No' | 'Block';
 
-interface Props {
-  user: UserInfoType;
-  className?: string;
-}
-
-export const ManageFriends = ({ user, className }: Props) => {
+export const ManageFriends = ({ user }: { user: UserInfoType }) => {
   const { friendList, refetch: refetchFriendList } = useGetFriendList();
   const { blockList, refetch: refetchBlockList } = useGetBlockList();
 
@@ -41,7 +36,7 @@ export const ManageFriends = ({ user, className }: Props) => {
   }
 
   return (
-    <div className={className}>
+    <div>
       {friendState === 'Friend' && (
         <>
           <button type="button" onClick={handleClickUnfriendOrBlock}>

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
@@ -1,7 +1,10 @@
 import { css } from '@emotion/css';
 
 export const matchHistoryContainerStyle = css({
-  display: 'inline-block',
+  display: 'grid',
+  gridTemplateAreas: `
+  'winner loser'
+  'time time'`,
 });
 
 export const matchHistoryWinnerStyle = css`

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
@@ -9,10 +9,21 @@ export const matchHistoryContainerStyle = css({
   gridTemplateColumns: '1fr 1fr',
 });
 
-export const matchHistoryWinnerStyle = css({
+export const matchHistoryBoxStyle = css({
   border: '1px solid black',
+  display: 'grid',
+  gridTemplateAreas: `
+  'img win'
+  'name name'`,
+  textAlign: 'center',
+  '& .win-lose': {
+    marginTop: '50px',
+  },
 });
 
-export const matchHistoryLoserStyle = css({
-  border: '1px solid black',
+export const matchAvatarStyle = css({
+  height: '100px',
+  width: '100px',
+  borderRadius: '50%',
+  margin: '0.3rem',
 });

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
@@ -2,11 +2,15 @@ import { css } from '@emotion/css';
 
 export const matchHistoryContainerStyle = css({
   display: 'grid',
-  paddingBottom: '0.5rem',
+  padding: '0.5rem',
   gridTemplateAreas: `
   'winner loser'
   'time time'`,
   gridTemplateColumns: '1fr 1fr',
+  '& .time': {
+    gridArea: 'time',
+  },
+  borderBottom: '1px solid black',
 });
 
 export const matchHistoryBoxStyle = css({
@@ -15,9 +19,12 @@ export const matchHistoryBoxStyle = css({
   gridTemplateAreas: `
   'img win'
   'name name'`,
-  textAlign: 'center',
   '& .win-lose': {
+    textAlign: 'center',
     marginTop: '50px',
+  },
+  '& .nick': {
+    marginLeft: '0.3rem',
   },
 });
 

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
 
-export const matchHistoryContainerStyle = css({});
+export const matchHistoryContainerStyle = css({
+  display: 'inline-block',
+});
 
 export const matchHistoryWinnerStyle = css`
   background-color: #bbdefb;

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
@@ -2,17 +2,17 @@ import { css } from '@emotion/css';
 
 export const matchHistoryContainerStyle = css({
   display: 'grid',
+  paddingBottom: '0.5rem',
   gridTemplateAreas: `
   'winner loser'
   'time time'`,
+  gridTemplateColumns: '1fr 1fr',
 });
 
-export const matchHistoryWinnerStyle = css`
-  background-color: #bbdefb;
-  border: 1px solid black;
-`;
+export const matchHistoryWinnerStyle = css({
+  border: '1px solid black',
+});
 
-export const matchHistoryLoserStyle = css`
-  background-color: #ef9a9a;
-  border: 1px solid black;
-`;
+export const matchHistoryLoserStyle = css({
+  border: '1px solid black',
+});

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.style.ts
@@ -1,11 +1,13 @@
 import { css } from '@emotion/css';
 
-export const tmpMatchHistoryWinnerStyle = css`
+export const matchHistoryContainerStyle = css({});
+
+export const matchHistoryWinnerStyle = css`
   background-color: #bbdefb;
   border: 1px solid black;
 `;
 
-export const tmpMatchHistoryLoserStyle = css`
+export const matchHistoryLoserStyle = css`
   background-color: #ef9a9a;
   border: 1px solid black;
 `;

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -1,7 +1,6 @@
 import { MatchHistoryType } from 'types/profile';
 
-import { tmpAvatarStyle } from '../tmpAvatarStyle';
-import { matchHistoryContainerStyle, matchHistoryLoserStyle, matchHistoryWinnerStyle } from './MatchHistory.style';
+import { matchAvatarStyle, matchHistoryContainerStyle, matchHistoryBoxStyle } from './MatchHistory.style';
 
 interface Props {
   history: MatchHistoryType;
@@ -10,13 +9,15 @@ interface Props {
 export const MatchHistory = ({ history }: Props) => {
   return (
     <div className={matchHistoryContainerStyle}>
-      <div className={matchHistoryWinnerStyle}>
-        <img className={tmpAvatarStyle} src={history.winner.avatar} width={100} height={100} alt="winnerAvatar" />
-        <span>Win : {history.winner.nickname}</span>
+      <div className={matchHistoryBoxStyle}>
+        <img className={matchAvatarStyle} src={history.winner.avatar} width={100} height={100} alt="winnerAvatar" />
+        <span className="win-lose">WIN</span>
+        <span>{history.winner.nickname}</span>
       </div>
-      <div className={matchHistoryLoserStyle}>
-        <img className={tmpAvatarStyle} src={history.loser.avatar} width={100} height={100} alt="loserAvatar" />
-        <span>Lose : {history.loser.nickname}</span>
+      <div className={matchHistoryBoxStyle}>
+        <img className={matchAvatarStyle} src={history.loser.avatar} width={100} height={100} alt="loserAvatar" />
+        <span className="win-lose">LOSE</span>
+        <span>{history.loser.nickname}</span>
       </div>
       <div className="date">Match Time: {history.createdAt}</div>
     </div>

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -1,7 +1,7 @@
 import { MatchHistoryType } from 'types/profile';
 
 import { tmpAvatarStyle } from '../tmpAvatarStyle';
-import { tmpMatchHistoryLoserStyle, tmpMatchHistoryWinnerStyle } from './tmpMatchHistory.style';
+import { matchHistoryContainerStyle, matchHistoryLoserStyle, matchHistoryWinnerStyle } from './MatchHistory.style';
 
 interface Props {
   history: MatchHistoryType;
@@ -9,12 +9,12 @@ interface Props {
 
 export const MatchHistory = ({ history }: Props) => {
   return (
-    <div>
-      <div className={tmpMatchHistoryWinnerStyle}>
+    <div className={matchHistoryContainerStyle}>
+      <div className={matchHistoryWinnerStyle}>
         <img className={tmpAvatarStyle} src={history.winner.avatar} width={100} height={100} alt="winnerAvatar" />
         <span>Win : {history.winner.nickname}</span>
       </div>
-      <div className={tmpMatchHistoryLoserStyle}>
+      <div className={matchHistoryLoserStyle}>
         <img className={tmpAvatarStyle} src={history.loser.avatar} width={100} height={100} alt="loserAvatar" />
         <span>Lose : {history.loser.nickname}</span>
       </div>

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -12,14 +12,14 @@ export const MatchHistory = ({ history }: Props) => {
       <div className={matchHistoryBoxStyle}>
         <img className={matchAvatarStyle} src={history.winner.avatar} width={100} height={100} alt="winnerAvatar" />
         <span className="win-lose">WIN</span>
-        <span>{history.winner.nickname}</span>
+        <span className="nick">{history.winner.nickname}</span>
       </div>
       <div className={matchHistoryBoxStyle}>
         <img className={matchAvatarStyle} src={history.loser.avatar} width={100} height={100} alt="loserAvatar" />
         <span className="win-lose">LOSE</span>
-        <span>{history.loser.nickname}</span>
+        <span className="nick">{history.loser.nickname}</span>
       </div>
-      <div className="date">Match Time: {history.createdAt}</div>
+      <div className="time">Match Time: {history.createdAt}</div>
     </div>
   );
 };

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -4,9 +4,10 @@ import { MatchHistory } from './MatchHistory';
 
 interface Props {
   userId: number;
+  className?: string;
 }
 
-export const MatchHistoryList = ({ userId }: Props) => {
+export const MatchHistoryList = ({ userId, className }: Props) => {
   // DUMMY INITIALIZE ***
   const user1 = useGetUser('1').data;
   const user2 = useGetUser('2').data;
@@ -27,7 +28,7 @@ export const MatchHistoryList = ({ userId }: Props) => {
   ];
   // ***
   return (
-    <main>
+    <main className={className}>
       <h1>Match History List</h1>
       <h2> debug: ID : {userId}</h2>
       {DUMMY_MATCH_HISTORY.map((value: MatchHistoryType) => (

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -28,12 +28,12 @@ export const MatchHistoryList = ({ userId, className }: Props) => {
   ];
   // ***
   return (
-    <main className={className}>
+    <div className={className}>
       <h1>Match History List</h1>
       <h2> debug: ID : {userId}</h2>
       {DUMMY_MATCH_HISTORY.map((value: MatchHistoryType) => (
         <MatchHistory key={value.id} history={value} />
       ))}
-    </main>
+    </div>
   );
 };

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 
 export const profileContainerStyle = css({
   display: 'grid',
-  padding: '0.5rem',
   width: '100vw',
   height: '100vh',
   gridTemplateAreas: `
@@ -12,10 +11,12 @@ export const profileContainerStyle = css({
 
 export const cardStyle = css({
   gridArea: 'card',
+  borderBottom: '2px solid black',
 });
 
 export const histStyle = css({
   gridArea: 'hist',
+  borderRight: '2px solid black',
 });
 
 export const achvStyle = css({

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/css';
+
+export const profileContainerStyle = css({
+  display: 'grid',
+  padding: '0.5rem',
+  width: '100vw',
+  height: '100vh',
+  gridTemplateAreas: ['card card', 'hist achv'],
+});
+
+export const cardStyle = css({
+  gridArea: 'card',
+});
+
+export const histStyle = css({
+  gridArea: 'hist',
+});
+
+export const achvStyle = css({
+  gridArea: 'achv',
+});

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -5,7 +5,9 @@ export const profileContainerStyle = css({
   padding: '0.5rem',
   width: '100vw',
   height: '100vh',
-  gridTemplateAreas: ['card card', 'hist achv'],
+  gridTemplateAreas: `
+  'card card'
+  'hist achv'`,
 });
 
 export const cardStyle = css({

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -9,7 +9,6 @@ export const profileContainerStyle = css({
   'hist achv'
   'hist achv'`,
   gridTemplateColumns: '1fr 1fr',
-  gridTemplateRows: '1fr 1fr 1fr',
 });
 
 export const cardStyle = css({

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -9,6 +9,7 @@ export const profileContainerStyle = css({
   'hist achv'
   'hist achv'`,
   gridTemplateColumns: '1fr 1fr',
+  gridTemplateRows: '1fr 1fr 1fr',
 });
 
 export const cardStyle = css({

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -13,17 +13,14 @@ export const profileContainerStyle = css({
 
 export const cardStyle = css({
   gridArea: 'card',
-  padding: '0.5rem',
   borderBottom: '1px solid black',
 });
 
 export const histStyle = css({
   gridArea: 'hist',
-  padding: '0.5rem',
   borderRight: '1px solid black',
 });
 
 export const achvStyle = css({
   gridArea: 'achv',
-  padding: '0.5rem',
 });

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -8,6 +8,7 @@ export const profileContainerStyle = css({
   'card card'
   'hist achv'
   'hist achv'`,
+  gridTemplateColumns: '1fr 1fr',
 });
 
 export const cardStyle = css({

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -6,6 +6,7 @@ export const profileContainerStyle = css({
   height: '100vh',
   gridTemplateAreas: `
   'card card'
+  'hist achv'
   'hist achv'`,
 });
 

--- a/frontend/src/pages/ProfilePage/Profile.style.ts
+++ b/frontend/src/pages/ProfilePage/Profile.style.ts
@@ -11,14 +11,17 @@ export const profileContainerStyle = css({
 
 export const cardStyle = css({
   gridArea: 'card',
-  borderBottom: '2px solid black',
+  padding: '0.5rem',
+  borderBottom: '1px solid black',
 });
 
 export const histStyle = css({
   gridArea: 'hist',
-  borderRight: '2px solid black',
+  padding: '0.5rem',
+  borderRight: '1px solid black',
 });
 
 export const achvStyle = css({
   gridArea: 'achv',
+  padding: '0.5rem',
 });

--- a/frontend/src/pages/ProfilePage/ProfileCard.style.ts
+++ b/frontend/src/pages/ProfilePage/ProfileCard.style.ts
@@ -34,10 +34,11 @@ export const profileCardAvatarStyle = css({
 });
 
 export const editProfileButtonStyle = css({
-  display: 'inline-flex',
+  display: 'inline-block',
   padding: '10px',
 });
 
 export const twoFactorAuthStyle = css({
-  display: 'inline-flex',
+  display: 'inline-block',
+  padding: '10px',
 });

--- a/frontend/src/pages/ProfilePage/ProfileCard.style.ts
+++ b/frontend/src/pages/ProfilePage/ProfileCard.style.ts
@@ -32,3 +32,7 @@ export const profileCardAvatarStyle = css({
   borderRadius: '50%',
   margin: '5%',
 });
+
+export const editProfileButtonStyle = css({});
+
+export const TwoFactorAuthStyle = css({});

--- a/frontend/src/pages/ProfilePage/ProfileCard.style.ts
+++ b/frontend/src/pages/ProfilePage/ProfileCard.style.ts
@@ -33,6 +33,11 @@ export const profileCardAvatarStyle = css({
   margin: '5%',
 });
 
-export const editProfileButtonStyle = css({});
+export const editProfileButtonStyle = css({
+  display: 'inline-flex',
+  padding: '10px',
+});
 
-export const TwoFactorAuthStyle = css({});
+export const twoFactorAuthStyle = css({
+  display: 'inline-flex',
+});

--- a/frontend/src/pages/ProfilePage/ProfileCard.style.ts
+++ b/frontend/src/pages/ProfilePage/ProfileCard.style.ts
@@ -1,0 +1,34 @@
+import { css } from '@emotion/css';
+
+export const profileCardStyle = css({
+  display: 'grid',
+  gridTemplateAreas: `
+  'img nick point-text'
+  'img nick point'`,
+  gridTemplateColumns: '230px 230px 230px',
+  gridTemplateRows: '130px 130px',
+  textAlign: 'center',
+  fontSize: '2.5rem',
+  '& .avatar': {
+    gridArea: 'img',
+  },
+  '& .nick': {
+    gridArea: 'nick',
+    marginTop: '120px',
+  },
+  '& .point-text': {
+    gridArea: 'point-text',
+    marginTop: '90px',
+  },
+  '& .point': {
+    gridArea: 'point',
+    marginTop: '25px',
+  },
+});
+
+export const profileCardAvatarStyle = css({
+  height: '200px',
+  width: '200px',
+  borderRadius: '50%',
+  margin: '5%',
+});

--- a/frontend/src/pages/ProfilePage/ProfileCard.tsx
+++ b/frontend/src/pages/ProfilePage/ProfileCard.tsx
@@ -1,10 +1,15 @@
 import { UserInfoType } from 'types/user';
 import { profileCardAvatarStyle, profileCardStyle } from './ProfileCard.style';
 
-export const ProfileCard = ({ user }: { user: UserInfoType }) => {
+interface Props {
+  user: UserInfoType;
+  className?: string;
+}
+
+export const ProfileCard = ({ user, className }: Props) => {
   const { nickname, point, avatar } = user;
   return (
-    <div className={profileCardStyle}>
+    <div className={`${className} ${profileCardStyle}`}>
       <img className={`avatar ${profileCardAvatarStyle}`} src={avatar} width={200} height={200} alt="avatar" />
       <span className="nick">{nickname}</span>
       <span className="point-text">point</span>

--- a/frontend/src/pages/ProfilePage/ProfileCard.tsx
+++ b/frontend/src/pages/ProfilePage/ProfileCard.tsx
@@ -1,13 +1,14 @@
 import { UserInfoType } from 'types/user';
-import { tmpAvatarStyle } from './tmpAvatarStyle';
+import { profileCardAvatarStyle, profileCardStyle } from './ProfileCard.style';
 
 export const ProfileCard = ({ user }: { user: UserInfoType }) => {
   const { nickname, point, avatar } = user;
   return (
-    <div>
-      <img className={tmpAvatarStyle} src={avatar} width={100} height={100} alt="avatar" />
-      <h1>{nickname}</h1>
-      <p>point : {point}</p>
+    <div className={profileCardStyle}>
+      <img className={`avatar ${profileCardAvatarStyle}`} src={avatar} width={200} height={200} alt="avatar" />
+      <span className="nick">{nickname}</span>
+      <span className="point-text">point</span>
+      <span className="point">{point}</span>
     </div>
   );
 };

--- a/frontend/src/pages/ProfilePage/ProfileCard.tsx
+++ b/frontend/src/pages/ProfilePage/ProfileCard.tsx
@@ -1,15 +1,10 @@
 import { UserInfoType } from 'types/user';
 import { profileCardAvatarStyle, profileCardStyle } from './ProfileCard.style';
 
-interface Props {
-  user: UserInfoType;
-  className?: string;
-}
-
-export const ProfileCard = ({ user, className }: Props) => {
+export const ProfileCard = ({ user }: { user: UserInfoType }) => {
   const { nickname, point, avatar } = user;
   return (
-    <div className={`${className} ${profileCardStyle}`}>
+    <div className={profileCardStyle}>
       <img className={`avatar ${profileCardAvatarStyle}`} src={avatar} width={200} height={200} alt="avatar" />
       <span className="nick">{nickname}</span>
       <span className="point-text">point</span>

--- a/frontend/src/pages/ProfilePage/TwoFactorAuth.tsx
+++ b/frontend/src/pages/ProfilePage/TwoFactorAuth.tsx
@@ -10,11 +10,7 @@ const DUMMY_2FA: TwoFactorAuthType = {
   isChecked: false,
 };
 
-interface Props {
-  className?: string;
-}
-
-export const TwoFactorAuth = ({ className }: Props) => {
+export const TwoFactorAuth = () => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
 
   function handleOpenModal() {
@@ -27,7 +23,7 @@ export const TwoFactorAuth = ({ className }: Props) => {
 
   return (
     <>
-      <div className={className}>
+      <div>
         <button type="button" onClick={handleOpenModal}>
           Two-Factor Authentication
         </button>

--- a/frontend/src/pages/ProfilePage/TwoFactorAuth.tsx
+++ b/frontend/src/pages/ProfilePage/TwoFactorAuth.tsx
@@ -10,7 +10,11 @@ const DUMMY_2FA: TwoFactorAuthType = {
   isChecked: false,
 };
 
-export const TwoFactorAuth = () => {
+interface Props {
+  className?: string;
+}
+
+export const TwoFactorAuth = ({ className }: Props) => {
   const [isModalShown, setModalShown] = useState<Boolean>(false);
 
   function handleOpenModal() {
@@ -23,7 +27,7 @@ export const TwoFactorAuth = () => {
 
   return (
     <>
-      <div>
+      <div className={className}>
         <button type="button" onClick={handleOpenModal}>
           Two-Factor Authentication
         </button>

--- a/frontend/src/pages/ProfilePage/TwoFactorAuth.tsx
+++ b/frontend/src/pages/ProfilePage/TwoFactorAuth.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { Modal } from 'common';
+import { twoFactorAuthStyle } from './ProfileCard.style';
 
 interface TwoFactorAuthType {
   isChecked: boolean;
@@ -23,7 +24,7 @@ export const TwoFactorAuth = () => {
 
   return (
     <>
-      <div>
+      <div className={twoFactorAuthStyle}>
         <button type="button" onClick={handleOpenModal}>
           Two-Factor Authentication
         </button>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -23,8 +23,8 @@ export const ProfilePage = () => {
         <ProfileCard user={profile} />
         {!id || profile.id === myProfile.id ? (
           <>
-            <TwoFactorAuth />
             <EditProfile user={profile} refetch={refetch} />
+            <TwoFactorAuth />
           </>
         ) : (
           <ManageFriends user={profile} />

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -19,7 +19,6 @@ export const ProfilePage = () => {
   if (!profile) return <span>error</span>;
   return (
     <main className={profileContainerStyle}>
-      <h1>Profile Page</h1>
       <div className={cardStyle}>
         <ProfileCard user={profile} />
         {!id || profile.id === myProfile.id ? (

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -9,6 +9,8 @@ import { AchievementList } from './Achievement';
 import { TwoFactorAuth } from './TwoFactorAuth';
 import { EditProfile } from './EditProfile';
 
+import { achvStyle, cardStyle, histStyle, profileContainerStyle } from './Profile.style';
+
 export const ProfilePage = () => {
   const { id } = useParams();
   const { data: profile, refetch } = useGetUser(id);
@@ -16,19 +18,21 @@ export const ProfilePage = () => {
 
   if (!profile) return <span>error</span>;
   return (
-    <main>
+    <main className={profileContainerStyle}>
       <h1>Profile Page</h1>
-      <ProfileCard user={profile} />
-      {!id || profile.id === myProfile.id ? (
-        <>
-          <TwoFactorAuth />
-          <EditProfile user={profile} refetch={refetch} />
-        </>
-      ) : (
-        <ManageFriends user={profile} />
-      )}
-      <MatchHistoryList userId={profile.id} />
-      <AchievementList userId={profile.id} />
+      <div className={cardStyle}>
+        <ProfileCard user={profile} />
+        {!id || profile.id === myProfile.id ? (
+          <>
+            <TwoFactorAuth />
+            <EditProfile user={profile} refetch={refetch} />
+          </>
+        ) : (
+          <ManageFriends user={profile} />
+        )}
+      </div>
+      <MatchHistoryList className={histStyle} userId={profile.id} />
+      <AchievementList className={achvStyle} userId={profile.id} />
     </main>
   );
 };

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -20,14 +20,14 @@ export const ProfilePage = () => {
   return (
     <main className={profileContainerStyle}>
       <div className={cardStyle}>
-        <ProfileCard user={profile} />
+        <ProfileCard className="card" user={profile} />
         {!id || profile.id === myProfile.id ? (
           <>
-            <EditProfile user={profile} refetch={refetch} />
-            <TwoFactorAuth />
+            <EditProfile className="edit" user={profile} refetch={refetch} />
+            <TwoFactorAuth className="2fa" />
           </>
         ) : (
-          <ManageFriends user={profile} />
+          <ManageFriends className="friend" user={profile} />
         )}
       </div>
       <MatchHistoryList className={histStyle} userId={profile.id} />

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -20,14 +20,14 @@ export const ProfilePage = () => {
   return (
     <main className={profileContainerStyle}>
       <div className={cardStyle}>
-        <ProfileCard className="card" user={profile} />
+        <ProfileCard user={profile} />
         {!id || profile.id === myProfile.id ? (
           <>
-            <EditProfile className="edit" user={profile} refetch={refetch} />
-            <TwoFactorAuth className="2fa" />
+            <EditProfile user={profile} refetch={refetch} />
+            <TwoFactorAuth />
           </>
         ) : (
-          <ManageFriends className="friend" user={profile} />
+          <ManageFriends user={profile} />
         )}
       </div>
       <MatchHistoryList className={histStyle} userId={profile.id} />

--- a/frontend/src/pages/ProfilePage/tmpProfileStyle.ts
+++ b/frontend/src/pages/ProfilePage/tmpProfileStyle.ts
@@ -1,0 +1,5 @@
+import { css } from '@emotion/css';
+
+export const tmpProfileContainerStyle = css({
+  display: 'grid',
+});

--- a/frontend/src/pages/ProfilePage/tmpProfileStyle.ts
+++ b/frontend/src/pages/ProfilePage/tmpProfileStyle.ts
@@ -1,5 +1,0 @@
-import { css } from '@emotion/css';
-
-export const tmpProfileContainerStyle = css({
-  display: 'grid',
-});


### PR DESCRIPTION
프로필 페이지를 보는데 컴포넌트가 추가되는게 늘어나니까 너무 가독성이 떨어져서,
기본적인 레이아웃만 일단 잡아놓기 위해 스타일 조금만 추가했습니다 !

우선은 Match Histroy, Achievement 에 API 적용하는 것이 급선무기 때문에,
개선 사항은 다음 Style PR 에 반영하겠습니다 !

![Screenshot from 2023-02-24 15-44-00](https://user-images.githubusercontent.com/62825700/221110458-811cbbdf-0041-4604-a01c-e8d07ddb3762.png)


----
### 다음 Style 브랜치 앞으로 개선 사항 :
1. Match Time 텍스트 위에 마진을 좀 주기
2. 각각의 매치 히스토리 박스에 패딩을 좀 주기
3. 각각 매치 히스토리 박스에는 보더를 빼기 ( 이미 보더 바텀이 있음 )
4. 매치 히스토리 닉네임 폭을 프로필 사진 폭이랑 맞추기
5. 닉네임이 너무 길 경우, ... 처리 하기
6. 매치 히스토리 맨 마지막에는 보더 바텀 빼기
