### PR TITLE
Feat/profile match api

### DIFF
--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -24,4 +24,7 @@ export const API = {
   // Friend/Block
   FRIEND: '/friend',
   BLOCK: '/friend/block',
+
+  // Match history
+  MATCH: '/match',
 } as const;

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useGetCurrentChatRoom } from './useGetCurrentChatRoom';
 export { useGetCurrentGameRoom } from './useGetCurrentGameRoom';
 export { useLogin } from './useLogin';
 export { useLogout } from './useLogout';
+export { useGetMatchHistory } from './useGetMatchHistory';

--- a/frontend/src/hooks/useGetMatchHistory.ts
+++ b/frontend/src/hooks/useGetMatchHistory.ts
@@ -1,5 +1,6 @@
-import { getMatchHistory } from 'services';
 import { useQuery } from 'react-query';
+
+import { getMatchHistory } from 'services';
 
 export function useGetMatchHistory(userId: number) {
   const { data: matchHistory = [], refetch } = useQuery(['match_history'], () => getMatchHistory(userId), {

--- a/frontend/src/hooks/useGetMatchHistory.ts
+++ b/frontend/src/hooks/useGetMatchHistory.ts
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query';
 import { getMatchHistory } from 'services';
 
 export function useGetMatchHistory(userId: number) {
-  const { data: matchHistory = [], refetch } = useQuery(['match_history'], () => getMatchHistory(userId), {
+  const { data: matchHistory = [], refetch } = useQuery([`match_history_${userId}`], () => getMatchHistory(userId), {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60,
     cacheTime: 1000 * 60,

--- a/frontend/src/hooks/useGetMatchHistory.ts
+++ b/frontend/src/hooks/useGetMatchHistory.ts
@@ -1,0 +1,13 @@
+import { getMatchHistory } from 'services';
+import { useQuery } from 'react-query';
+
+export function useGetMatchHistory(userId: number) {
+  const { data: matchHistory = [], refetch } = useQuery(['match_history'], () => getMatchHistory(userId), {
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60,
+    cacheTime: 1000 * 60,
+    retry: 0,
+    useErrorBoundary: true,
+  });
+  return { matchHistory, refetch };
+}

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -5,13 +5,23 @@ import { MatchHistoryBox } from './MatchHistoryBox';
 
 interface Props {
   history: MatchHistoryType;
+  userId: number;
 }
 
-export const MatchHistory = ({ history }: Props) => {
+export const MatchHistory = ({ history, userId }: Props) => {
   return (
     <div className={matchHistoryContainerStyle}>
-      <MatchHistoryBox user={history.winner} result="WIN" />
-      <MatchHistoryBox user={history.loser} result="LOSE" />
+      {userId === history.winner.id ? (
+        <>
+          <MatchHistoryBox user={history.winner} result="WIN" />
+          <MatchHistoryBox user={history.loser} result="LOSE" />
+        </>
+      ) : (
+        <>
+          <MatchHistoryBox user={history.loser} result="LOSE" />
+          <MatchHistoryBox user={history.winner} result="WIN" />
+        </>
+      )}
       <div className="time">Match Time: {history.createdAt}</div>
     </div>
   );

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -10,18 +10,8 @@ interface Props {
 export const MatchHistory = ({ history }: Props) => {
   return (
     <div className={matchHistoryContainerStyle}>
-      {/* <div className={matchHistoryBoxStyle}>
-        <img className={matchAvatarStyle} src={history.winner.avatar} width={100} height={100} alt="winnerAvatar" />
-        <span className="win-lose">WIN</span>
-        <span className="nick">{history.winner.nickname}</span>
-      </div>
-      <div className={matchHistoryBoxStyle}>
-        <img className={matchAvatarStyle} src={history.loser.avatar} width={100} height={100} alt="loserAvatar" />
-        <span className="win-lose">LOSE</span>
-        <span className="nick">{history.loser.nickname}</span>
-      </div> */}
-      <MatchHistoryBox user={history.winner} key="WIN" />
-      <MatchHistoryBox user={history.loser} key="LOSE" />
+      <MatchHistoryBox user={history.winner} result="WIN" />
+      <MatchHistoryBox user={history.loser} result="LOSE" />
       <div className="time">Match Time: {history.createdAt}</div>
     </div>
   );

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -1,6 +1,7 @@
 import { MatchHistoryType } from 'types/profile';
 
-import { matchAvatarStyle, matchHistoryContainerStyle, matchHistoryBoxStyle } from './MatchHistory.style';
+import { matchHistoryContainerStyle } from './MatchHistory.style';
+import { MatchHistoryBox } from './MatchHistoryBox';
 
 interface Props {
   history: MatchHistoryType;
@@ -9,7 +10,7 @@ interface Props {
 export const MatchHistory = ({ history }: Props) => {
   return (
     <div className={matchHistoryContainerStyle}>
-      <div className={matchHistoryBoxStyle}>
+      {/* <div className={matchHistoryBoxStyle}>
         <img className={matchAvatarStyle} src={history.winner.avatar} width={100} height={100} alt="winnerAvatar" />
         <span className="win-lose">WIN</span>
         <span className="nick">{history.winner.nickname}</span>
@@ -18,7 +19,9 @@ export const MatchHistory = ({ history }: Props) => {
         <img className={matchAvatarStyle} src={history.loser.avatar} width={100} height={100} alt="loserAvatar" />
         <span className="win-lose">LOSE</span>
         <span className="nick">{history.loser.nickname}</span>
-      </div>
+      </div> */}
+      <MatchHistoryBox user={history.winner} key="WIN" />
+      <MatchHistoryBox user={history.loser} key="LOSE" />
       <div className="time">Match Time: {history.createdAt}</div>
     </div>
   );

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistory.tsx
@@ -1,7 +1,7 @@
 import { MatchHistoryType } from 'types/profile';
+import { MatchHistoryBox } from './MatchHistoryBox';
 
 import { matchHistoryContainerStyle } from './MatchHistory.style';
-import { MatchHistoryBox } from './MatchHistoryBox';
 
 interface Props {
   history: MatchHistoryType;

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
@@ -8,10 +8,11 @@ interface Props {
 }
 
 export const MatchHistoryBox = ({ user, key }: Props) => {
+  console.log(key);
   return (
     <div className={matchHistoryBoxStyle}>
       <img className={matchAvatarStyle} src={user.avatar} width={100} height={100} alt={`${key}Avatar`} />
-      <span className="win-lose">{key}</span>
+      <span className="win-lose">{key === 'WIN' ? 'WIN' : 'LOSE'}</span>
       <span className="nick">{user.nickname}</span>
     </div>
   );

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
@@ -4,15 +4,14 @@ import { matchAvatarStyle, matchHistoryBoxStyle } from './MatchHistory.style';
 
 interface Props {
   user: UserInfoType;
-  key: 'WIN' | 'LOSE';
+  result: 'WIN' | 'LOSE';
 }
 
-export const MatchHistoryBox = ({ user, key }: Props) => {
-  console.log(key);
+export const MatchHistoryBox = ({ user, result }: Props) => {
   return (
     <div className={matchHistoryBoxStyle}>
-      <img className={matchAvatarStyle} src={user.avatar} width={100} height={100} alt={`${key}Avatar`} />
-      <span className="win-lose">{key === 'WIN' ? 'WIN' : 'LOSE'}</span>
+      <img className={matchAvatarStyle} src={user.avatar} width={100} height={100} alt={`${result}Avatar`} />
+      <span className="win-lose">{result}</span>
       <span className="nick">{user.nickname}</span>
     </div>
   );

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
@@ -1,3 +1,18 @@
-export const MatchHistoryBox = (key: string) => {
-  return <div></div>;
+import { UserInfoType } from 'types/user';
+
+import { matchAvatarStyle, matchHistoryBoxStyle } from './MatchHistory.style';
+
+interface Props {
+  user: UserInfoType;
+  key: 'WIN' | 'LOSE';
+}
+
+export const MatchHistoryBox = ({ user, key }: Props) => {
+  return (
+    <div className={matchHistoryBoxStyle}>
+      <img className={matchAvatarStyle} src={user.avatar} width={100} height={100} alt={`${key}Avatar`} />
+      <span className="win-lose">{key}</span>
+      <span className="nick">{user.nickname}</span>
+    </div>
+  );
 };

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryBox.tsx
@@ -1,0 +1,3 @@
+export const MatchHistoryBox = (key: string) => {
+  return <div></div>;
+};

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -10,8 +10,6 @@ interface Props {
 export const MatchHistoryList = ({ userId, className }: Props) => {
   const { matchHistory } = useGetMatchHistory(userId);
 
-  console.log(matchHistory);
-
   return (
     <div className={className}>
       <h1>Match History List</h1>

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -15,7 +15,7 @@ export const MatchHistoryList = ({ userId, className }: Props) => {
       <h1>Match History List</h1>
       <h2> debug: ID : {userId}</h2>
       {matchHistory.map((value: MatchHistoryType) => (
-        <MatchHistory key={value.id} history={value} />
+        <MatchHistory key={value.id} history={value} userId={userId} />
       ))}
     </div>
   );

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -8,7 +8,6 @@ interface Props {
 }
 
 export const MatchHistoryList = ({ userId, className }: Props) => {
-  // DUMMY INITIALIZE ***
   const user1 = useGetUser('1').data;
   const user2 = useGetUser('2').data;
 

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -10,21 +10,8 @@ interface Props {
 export const MatchHistoryList = ({ userId, className }: Props) => {
   const { matchHistory } = useGetMatchHistory(userId);
 
-  //   const DUMMY_MATCH_HISTORY = [
-  //     {
-  //       id: 1,
-  //       winner: user1,
-  //       loser: user2,
-  //       createdAt: '1970-01-01T00:00:00.000Z',
-  //     },
-  //     {
-  //       id: 2,
-  //       winner: user2,
-  //       loser: user1,
-  //       createdAt: '1970-01-01T00:00:00.000Z',
-  //     },
-  //   ];
-  // ***
+  console.log(matchHistory);
+
   return (
     <div className={className}>
       <h1>Match History List</h1>

--- a/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
+++ b/frontend/src/pages/ProfilePage/MatchHistory/MatchHistoryList.tsx
@@ -1,4 +1,4 @@
-import { useGetUser } from 'hooks';
+import { useGetMatchHistory } from 'hooks';
 import { MatchHistoryType } from 'types/profile';
 import { MatchHistory } from './MatchHistory';
 
@@ -8,29 +8,28 @@ interface Props {
 }
 
 export const MatchHistoryList = ({ userId, className }: Props) => {
-  const user1 = useGetUser('1').data;
-  const user2 = useGetUser('2').data;
+  const { matchHistory } = useGetMatchHistory(userId);
 
-  const DUMMY_MATCH_HISTORY = [
-    {
-      id: 1,
-      winner: user1,
-      loser: user2,
-      createdAt: '1970-01-01T00:00:00.000Z',
-    },
-    {
-      id: 2,
-      winner: user2,
-      loser: user1,
-      createdAt: '1970-01-01T00:00:00.000Z',
-    },
-  ];
+  //   const DUMMY_MATCH_HISTORY = [
+  //     {
+  //       id: 1,
+  //       winner: user1,
+  //       loser: user2,
+  //       createdAt: '1970-01-01T00:00:00.000Z',
+  //     },
+  //     {
+  //       id: 2,
+  //       winner: user2,
+  //       loser: user1,
+  //       createdAt: '1970-01-01T00:00:00.000Z',
+  //     },
+  //   ];
   // ***
   return (
     <div className={className}>
       <h1>Match History List</h1>
       <h2> debug: ID : {userId}</h2>
-      {DUMMY_MATCH_HISTORY.map((value: MatchHistoryType) => (
+      {matchHistory.map((value: MatchHistoryType) => (
         <MatchHistory key={value.id} history={value} />
       ))}
     </div>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -15,7 +15,7 @@ export const ProfilePage = () => {
   const { data: profile, refetch } = useGetUser(id);
   const { data: myProfile } = useGetUser();
 
-  if (!profile) return <span>error</span>;
+  if (profile.id === -1) return <span>Loading profile....</span>;
   return (
     <main className={profileContainerStyle}>
       <div className={cardStyle}>

--- a/frontend/src/services/getMatchHistory.ts
+++ b/frontend/src/services/getMatchHistory.ts
@@ -1,0 +1,7 @@
+import { API } from 'common/constants';
+import { UserInfoType } from 'types/user';
+import { axiosGet } from './axiosWrapper';
+
+export function getMatchHistory(userId: number): Promise<UserInfoType[]> {
+  return axiosGet<UserInfoType[]>(`${API.MATCH}/${userId}`);
+}

--- a/frontend/src/services/getMatchHistory.ts
+++ b/frontend/src/services/getMatchHistory.ts
@@ -1,7 +1,7 @@
 import { API } from 'common/constants';
-import { UserInfoType } from 'types/user';
+import { MatchHistoryType } from 'types/profile';
 import { axiosGet } from './axiosWrapper';
 
-export function getMatchHistory(userId: number): Promise<UserInfoType[]> {
-  return axiosGet<UserInfoType[]>(`${API.MATCH}/${userId}`);
+export function getMatchHistory(userId: number): Promise<MatchHistoryType[]> {
+  return axiosGet<MatchHistoryType[]>(`${API.MATCH}/${userId}`);
 }

--- a/frontend/src/services/getMatchHistory.ts
+++ b/frontend/src/services/getMatchHistory.ts
@@ -2,6 +2,6 @@ import { API } from 'common/constants';
 import { MatchHistoryType } from 'types/profile';
 import { axiosGet } from './axiosWrapper';
 
-export function getMatchHistory(userId: number): Promise<MatchHistoryType[]> {
+export async function getMatchHistory(userId: number): Promise<MatchHistoryType[]> {
   return axiosGet<MatchHistoryType[]>(`${API.MATCH}/${userId}`);
 }

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -7,3 +7,4 @@ export { postRegister } from './postRegister';
 export { deleteAuthSignout } from './deleteAuthSignout';
 export { putUserProfile } from './putUserProfile';
 export { getAllUserList } from './getAllUserList';
+export { getMatchHistory } from './getMatchHistory';


### PR DESCRIPTION
## 주요 수정사항
1. Match HIstory 더미 제거, API 콜 받아서 구현 !
2. 매치 히스토리에서 무조건 본인이 앞에 뜨도록 함.
ex) 본인이 이긴 경우 = WIN | LOSE
      본인이 진 경우    = LOSE | WIN

-----
### 기타 수정사항
- **refactor**
1. 매치 히스토리 winner 박스와 loser 박스가 비슷한 점이 많아서, 하나의 컴포넌트로 묶고 (MatchHistoryBox) 안에서 분기를 통해 win 과 lose 구별함.
2. profile page 에서 useGetUser 로 유저 데이터가 받아지기 전에는, INIT_DATA 가 유저로 들어오기 때문에 자꾸 매치 히스토리 컴포넌트가 match/-1 을 콜하는 문제가 있었음. 따라서 그동안엔 프로필 로딩을 띄우도록 함 ! 이거 중요해보여서 다른데도 잘 쓸거같음.
Thanks to @Skyrich2000 
----

![Screenshot from 2023-02-24 17-47-49](https://user-images.githubusercontent.com/62825700/221134462-951c3e1e-7c0a-427d-8a9d-2a2a223a5069.png)
fig 1. 본인이 이긴 경우

![Screenshot from 2023-02-24 17-50-55](https://user-images.githubusercontent.com/62825700/221134616-322da219-28ca-48b5-bace-89dd68b4784e.png)
fig 2. 본인이 진 경우
