### PR TITLE
Feat/이미지 업로드 이슈 핸들링

### DIFF
--- a/frontend/src/common/ChangeProfiles/ChangeAvatar.tsx
+++ b/frontend/src/common/ChangeProfiles/ChangeAvatar.tsx
@@ -30,7 +30,7 @@ export const ChangeAvatar = ({ imageUrl, onChange, className }: Props) => {
       <label htmlFor="change-image" className={changeAvatarImageUploadButtonStyle}>
         업로드
       </label>
-      <input type="file" id="change-image" onChange={handleChangeImage} />
+      <input type="file" id="change-image" accept="image/jpeg, image/jpg, image/png" onChange={handleChangeImage} />
       <img src={imageUrl} alt="change profile" className={changeAvatarImageStyle} />
     </div>
   );

--- a/frontend/src/common/ChangeProfiles/ChangeAvatar.tsx
+++ b/frontend/src/common/ChangeProfiles/ChangeAvatar.tsx
@@ -18,6 +18,16 @@ interface Props {
 
 export const ChangeAvatar = ({ imageUrl, onChange, className }: Props) => {
   function handleChangeImage(e: ChangeEvent<HTMLInputElement>) {
+    if (e.currentTarget.files[0].size > 1024 * 1024 * 2) {
+      alert(
+        '2MB 이하 파일만 등록할 수 있습니다.\n\n' +
+          '현재파일 용량 : ' +
+          Math.round((e.currentTarget.files[0].size / 1024 / 1024) * 100) / 100 +
+          'MB',
+      );
+      return;
+    }
+
     onChange(LOADING_IMAGE_URL);
     postFile({ file: e.currentTarget.files[0] }).then(res => {
       onChange(`${process.env.REACT_APP_SERVER}/file/${res}`);

--- a/frontend/src/common/ChangeProfiles/ChangeAvatar.tsx
+++ b/frontend/src/common/ChangeProfiles/ChangeAvatar.tsx
@@ -20,10 +20,9 @@ export const ChangeAvatar = ({ imageUrl, onChange, className }: Props) => {
   function handleChangeImage(e: ChangeEvent<HTMLInputElement>) {
     if (e.currentTarget.files[0].size > 1024 * 1024 * 2) {
       alert(
-        '2MB 이하 파일만 등록할 수 있습니다.\n\n' +
-          '현재파일 용량 : ' +
-          Math.round((e.currentTarget.files[0].size / 1024 / 1024) * 100) / 100 +
-          'MB',
+        `2MB 이하 파일만 등록할 수 있습니다.\n\n현재파일 용량 : ${
+          Math.round((e.currentTarget.files[0].size / 1024 / 1024) * 100) / 100
+        }MB`,
       );
       return;
     }


### PR DESCRIPTION

<img width="1119" alt="스크린샷 2023-03-01 오후 5 02 51" src="https://user-images.githubusercontent.com/73428595/222079604-119700b9-a414-478c-a489-c4b633ce8af0.png">

- 2MB 초과 이미지는 업로드 불가 및 얼럿 메세지 추가
- accept 파일 종류 및 확장자 고정 png, jpeg, jpg

이슈
- 이미지 파일 용량이 작아도 파일내에 정보 길이가 길면 에러 발생해서 업로드 불가