### PR TITLE
fix: Match Queue 자신과 자신이 매칭되는 버그 수정

### DIFF
--- a/backend/src/common/database/repository/game-match-queue.repository.ts
+++ b/backend/src/common/database/repository/game-match-queue.repository.ts
@@ -12,7 +12,7 @@ export class GameMatchQueueRepository {
   private gameMatchQueues: GameMatchQueue[] = [];
 
   public push(socketId: string, userId: number): void {
-    if (this.gameMatchQueues.find(queue => queue.socketId === socketId)) {
+    if (this.gameMatchQueues.find(queue => queue.userId === userId)) {
       return;
     }
 


### PR DESCRIPTION
- 자기 자신과 매칭되는 버그가 있습니다...
- Match Queue에 Enqueue하는 로직에서 SocketID로 검색하고 있었는데 userID를 통해서 본인 중복 확인하도록 바꿨습니다.